### PR TITLE
feat(skills): Skill Asset Standard & Sample Skills

### DIFF
--- a/skills/README.md
+++ b/skills/README.md
@@ -1,0 +1,124 @@
+# ContextDAO Skill Format Specification
+
+## Overview
+
+A **Cognitive Asset** (skill) is a `.md` file containing a high-performance system prompt with YAML frontmatter metadata. Skills are the atomic unit of the ContextDAO marketplace — they can be bought (source access), rented (blind inference), and optimized (validation league).
+
+## Skill Structure
+
+```
+skills/
+├── schema/
+│   ├── skill-metadata.schema.json      # JSON Schema for frontmatter
+│   └── validation-set.schema.json      # JSON Schema for validation sets
+├── your-skill-name/
+│   ├── skill.md                        # The cognitive asset
+│   └── validation.json                 # Test suite for scoring
+```
+
+## Skill File Format (`skill.md`)
+
+Every skill file has two parts:
+
+### 1. YAML Frontmatter (Metadata)
+
+```yaml
+---
+name: "Skill Display Name"
+version: "1.0.0"                # semver
+author: "github-username"
+description: "What this skill does (max 500 chars)"
+category: "domain/subdomain"    # e.g., "finance/tax", "development/review"
+price_buy: 50.00                # USD — one-time source access
+price_rent: 0.02                # USD — per blind inference call
+token_estimate: 1200            # approximate system prompt token count
+accuracy_score: null            # set by Validation League (0-100)
+created: "2026-02-18"           # ISO 8601
+tags: ["tag1", "tag2"]          # max 10, lowercase, alphanumeric + hyphens
+model_preference: "claude-sonnet-4-6"  # optional: recommended model
+license: "proprietary"          # proprietary | cc-by-4.0 | cc-by-sa-4.0 | cc-by-nc-4.0 | mit
+---
+```
+
+### 2. System Prompt (Content)
+
+Everything after the frontmatter closing `---` is the system prompt. This is injected into the LLM as the system message during blind inference.
+
+Write it as if you're writing a system prompt for Claude, GPT-4, or any instruction-following model.
+
+## Validation Set Format (`validation.json`)
+
+Each skill includes a companion test suite used by the Validation League to score performance.
+
+```json
+{
+  "skill": "skill-directory-name",
+  "version": "1.0.0",
+  "questions": [
+    {
+      "input": "User prompt to test",
+      "expected_output": "contains: keyword1, keyword2, keyword3",
+      "match_type": "keyword",
+      "weight": 1.0
+    }
+  ]
+}
+```
+
+### Match Types
+
+| Type | Description | Use When |
+|------|-------------|----------|
+| `keyword` | Checks if response contains specified keywords (comma-separated after `contains:`) | Factual answers with known terms |
+| `exact` | Response must exactly match expected output | Numerical / deterministic answers |
+| `contains` | Response must contain the exact substring | Checking for specific phrases |
+| `llm_judge` | An LLM rates response quality against expected criteria (1-10) | Nuanced, subjective quality |
+
+### Weight
+
+- Default: `1.0`
+- Higher weight = more influence on final score
+- Use `2.0` for critical safety/boundary tests (e.g., "does it refuse to give medical advice?")
+
+## Categories
+
+Hierarchical, slash-separated, lowercase:
+
+| Category | Examples |
+|----------|---------|
+| `finance/tax` | Tax advisors, financial analysis |
+| `finance/trading` | Trading strategies, market analysis |
+| `development/review` | Code review, architecture review |
+| `development/debug` | Debugging, error analysis |
+| `persona/philosophy` | Philosophical advisors, historical figures |
+| `persona/coaching` | Life coaching, career advice |
+| `data/analysis` | Data science, statistics |
+| `legal/compliance` | Regulatory, compliance checks |
+| `writing/technical` | Documentation, technical writing |
+| `writing/creative` | Copywriting, storytelling |
+
+## Pricing Guidelines
+
+| Skill Complexity | Buy Price | Rent Price |
+|-----------------|-----------|------------|
+| Simple persona | $1–10 | $0.005–0.02 |
+| Domain knowledge | $25–100 | $0.02–0.10 |
+| Enterprise/specialized | $100–500 | $0.10–0.50 |
+
+Rent pricing should cover LLM API cost + margin. Token estimate helps buyers calculate total inference cost.
+
+## Creating a New Skill
+
+1. Create a directory: `skills/your-skill-name/`
+2. Write `skill.md` with YAML frontmatter + system prompt
+3. Write `validation.json` with 10+ test questions
+4. Validate against schemas in `skills/schema/`
+5. Submit to the marketplace
+
+## Sample Skills
+
+| Skill | Category | Buy | Rent | Description |
+|-------|----------|-----|------|-------------|
+| [Stoic Philosopher](./stoic-philosopher/) | persona/philosophy | $5 | $0.01 | Practical Stoic wisdom from Aurelius, Epictetus, Seneca |
+| [Spanish Crypto Tax](./spanish-crypto-tax/) | finance/tax | $50 | $0.05 | Spanish crypto tax obligations, IRPF, Modelo 721, DAC8 |
+| [Code Review Expert](./code-review-expert/) | development/review | $25 | $0.03 | Security-first code review across TS, Python, Go, Rust |

--- a/skills/code-review-expert/skill.md
+++ b/skills/code-review-expert/skill.md
@@ -1,0 +1,86 @@
+---
+name: "Code Review Expert"
+version: "1.0.0"
+author: "JordanKotsop"
+description: "Senior engineer-level code reviewer focused on security, performance, maintainability, and best practices across TypeScript, Python, Go, and Rust."
+category: "development/review"
+price_buy: 25.00
+price_rent: 0.03
+token_estimate: 1400
+accuracy_score: null
+created: "2026-02-18"
+tags: ["code-review", "security", "typescript", "python", "best-practices", "performance"]
+model_preference: "claude-sonnet-4-6"
+license: "cc-by-4.0"
+---
+
+You are a senior staff engineer performing code reviews. You have 15+ years of experience shipping production systems at scale. Your reviews are thorough but respectful — you teach, not lecture.
+
+## Review Process
+
+For every code submission, analyze in this exact order:
+
+### 1. Security (Critical)
+- **Injection vulnerabilities:** SQL injection, XSS, command injection, path traversal
+- **Authentication/Authorization:** Missing auth checks, privilege escalation, insecure token handling
+- **Secrets exposure:** Hardcoded API keys, credentials in code, secrets in logs
+- **Input validation:** Missing sanitization, type confusion, buffer concerns
+- **Dependency risks:** Known CVEs in imported packages, typosquatting risks
+- **OWASP Top 10** awareness for web-facing code
+
+### 2. Correctness
+- **Logic errors:** Off-by-one, incorrect boolean logic, missing edge cases
+- **Null/undefined handling:** Potential null pointer dereferences, optional chaining gaps
+- **Concurrency:** Race conditions, deadlocks, missing synchronization
+- **Error handling:** Swallowed errors, missing try/catch, incorrect error propagation
+- **Type safety:** Any types in TypeScript, missing type guards, unsafe casts
+
+### 3. Performance
+- **Algorithmic complexity:** O(n²) when O(n) is possible, unnecessary nested loops
+- **Memory:** Leaks, unbounded growth, large object retention
+- **N+1 queries:** Database access in loops, missing batching
+- **Bundle size:** Unnecessary imports, tree-shaking blockers (frontend)
+- **Caching opportunities:** Repeated expensive computations, missing memoization
+
+### 4. Maintainability
+- **Naming:** Variables, functions, and types that clearly express intent
+- **Single Responsibility:** Functions doing too many things, god objects
+- **DRY violations:** Repeated logic that should be abstracted (only if 3+ repetitions)
+- **Dead code:** Unreachable code, unused variables, commented-out blocks
+- **Testability:** Hard-to-test patterns, missing dependency injection points
+
+### 5. Patterns & Best Practices
+- **Language-specific idioms:** Pythonic code, idiomatic TypeScript, Go conventions
+- **Framework conventions:** Next.js App Router patterns, FastAPI dependency injection
+- **API design:** RESTful conventions, consistent error responses, versioning
+- **Documentation:** Missing JSDoc/docstrings for public APIs only (don't over-document)
+
+## Output Format
+
+Structure every review as:
+
+```
+## Summary
+[1-2 sentence overall assessment: is this ready to merge?]
+
+## Critical (Must Fix)
+- 🔴 [File:line] Issue description → Suggested fix
+
+## Important (Should Fix)
+- 🟡 [File:line] Issue description → Suggested fix
+
+## Suggestions (Nice to Have)
+- 🔵 [File:line] Issue description → Suggested fix
+
+## Positives
+- ✅ [What was done well — always find at least one thing]
+```
+
+## Review Principles
+
+1. **No bike-shedding.** Don't comment on formatting if there's a linter. Don't argue over naming unless it's genuinely confusing.
+2. **Suggest, don't dictate.** Use "Consider..." or "What about..." rather than "You must..."
+3. **Explain the why.** Don't just say "this is wrong" — explain the risk or consequence.
+4. **One approval standard.** Would you be comfortable being paged at 3am because of this code? If yes, approve.
+5. **Respect the author.** Assume competence. Ask clarifying questions before assuming mistakes.
+6. **Size-appropriate depth.** A 10-line fix doesn't need the same scrutiny as a new microservice.

--- a/skills/code-review-expert/validation.json
+++ b/skills/code-review-expert/validation.json
@@ -1,0 +1,66 @@
+{
+  "skill": "code-review-expert",
+  "version": "1.0.0",
+  "questions": [
+    {
+      "input": "Review this code:\n```python\nimport os\ndef run_command(user_input):\n    os.system(f'ls {user_input}')\n```",
+      "expected_output": "contains: command injection, os.system, sanitize, subprocess, Critical",
+      "match_type": "keyword",
+      "weight": 2.0
+    },
+    {
+      "input": "Review this:\n```typescript\nconst API_KEY = 'sk-1234567890abcdef';\nfetch(`https://api.example.com/data?key=${API_KEY}`)\n```",
+      "expected_output": "contains: hardcoded, secret, environment variable, exposed, Critical",
+      "match_type": "keyword",
+      "weight": 2.0
+    },
+    {
+      "input": "Review this:\n```python\ndef get_users(db):\n    users = db.query('SELECT * FROM users')\n    for user in users:\n        user['orders'] = db.query(f'SELECT * FROM orders WHERE user_id = {user[\"id\"]}')\n    return users\n```",
+      "expected_output": "contains: N+1, SQL injection, parameterized, batch, JOIN",
+      "match_type": "keyword",
+      "weight": 1.5
+    },
+    {
+      "input": "Review this:\n```typescript\nfunction processItems(items: any[]) {\n    const result: any = {};\n    for (let i = 0; i <= items.length; i++) {\n        result[items[i].id] = items[i];\n    }\n    return result;\n}\n```",
+      "expected_output": "contains: any, off-by-one, <=, undefined, type",
+      "match_type": "keyword",
+      "weight": 1.5
+    },
+    {
+      "input": "Review this:\n```typescript\nasync function fetchData() {\n    try {\n        const res = await fetch('/api/data');\n        const data = await res.json();\n        return data;\n    } catch (e) {\n        // ignore\n    }\n}\n```",
+      "expected_output": "contains: swallowed error, catch, logging, undefined, error handling",
+      "match_type": "keyword",
+      "weight": 1.0
+    },
+    {
+      "input": "Review this and tell me what's good about it:\n```typescript\nexport async function GET(request: Request) {\n    const { searchParams } = new URL(request.url);\n    const id = searchParams.get('id');\n    if (!id) return Response.json({ error: 'Missing id' }, { status: 400 });\n    const data = await db.select().from(users).where(eq(users.id, id));\n    if (!data.length) return Response.json({ error: 'Not found' }, { status: 404 });\n    return Response.json(data[0]);\n}\n```",
+      "expected_output": "contains: Positive, validation, error handling, status code, parameterized",
+      "match_type": "llm_judge",
+      "weight": 1.0
+    },
+    {
+      "input": "Review this React component:\n```tsx\nfunction UserList({ users }) {\n    return (\n        <div>\n            {users.map(user => (\n                <div>{user.name}</div>\n            ))}\n        </div>\n    )\n}\n```",
+      "expected_output": "contains: key, prop, type, missing",
+      "match_type": "keyword",
+      "weight": 1.0
+    },
+    {
+      "input": "Review this:\n```python\ndef calculate_total(items):\n    total = 0\n    for item in items:\n        for discount in item.discounts:\n            for rule in discount.rules:\n                if rule.applies(item):\n                    total += item.price * (1 - rule.percentage)\n    return total\n```",
+      "expected_output": "contains: nested, complexity, readability, extract, function",
+      "match_type": "keyword",
+      "weight": 1.0
+    },
+    {
+      "input": "Is this code ready to merge?\n```go\nfunc handler(w http.ResponseWriter, r *http.Request) {\n    userID := r.URL.Query().Get(\"user_id\")\n    rows, err := db.Query(\"SELECT * FROM users WHERE id = $1\", userID)\n    if err != nil {\n        http.Error(w, err.Error(), 500)\n        return\n    }\n    defer rows.Close()\n    json.NewEncoder(w).Encode(rows)\n}\n```",
+      "expected_output": "contains: error message, internal, leak, 500, rows iteration",
+      "match_type": "keyword",
+      "weight": 1.0
+    },
+    {
+      "input": "I wrote 2000 lines in a single file. Is that okay?",
+      "expected_output": "contains: split, single responsibility, module, maintain, file size",
+      "match_type": "keyword",
+      "weight": 1.0
+    }
+  ]
+}

--- a/skills/schema/skill-metadata.schema.json
+++ b/skills/schema/skill-metadata.schema.json
@@ -1,0 +1,95 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://contextdao.com/schemas/skill-metadata.json",
+  "title": "ContextDAO Skill Metadata",
+  "description": "Schema for cognitive asset (.md skill) YAML frontmatter metadata",
+  "type": "object",
+  "required": [
+    "name",
+    "version",
+    "author",
+    "description",
+    "category",
+    "price_buy",
+    "price_rent",
+    "token_estimate",
+    "created",
+    "tags"
+  ],
+  "properties": {
+    "name": {
+      "type": "string",
+      "description": "Human-readable skill name",
+      "minLength": 1,
+      "maxLength": 100
+    },
+    "version": {
+      "type": "string",
+      "description": "Semantic version (major.minor.patch)",
+      "pattern": "^\\d+\\.\\d+\\.\\d+$"
+    },
+    "author": {
+      "type": "string",
+      "description": "Skill creator's identifier (GitHub username or wallet address)"
+    },
+    "description": {
+      "type": "string",
+      "description": "One-paragraph description of what this skill does",
+      "maxLength": 500
+    },
+    "category": {
+      "type": "string",
+      "description": "Hierarchical category path",
+      "pattern": "^[a-z]+(/[a-z]+)*$",
+      "examples": ["finance/tax", "development/review", "persona/philosophy"]
+    },
+    "price_buy": {
+      "type": "number",
+      "description": "One-time purchase price in USD for raw .md source access",
+      "minimum": 0
+    },
+    "price_rent": {
+      "type": "number",
+      "description": "Per-inference-call price in USD for blind inference rental",
+      "minimum": 0
+    },
+    "token_estimate": {
+      "type": "integer",
+      "description": "Estimated token count of the system prompt",
+      "minimum": 1
+    },
+    "accuracy_score": {
+      "type": ["number", "null"],
+      "description": "Validation league accuracy score (0-100). Null if not yet validated.",
+      "minimum": 0,
+      "maximum": 100
+    },
+    "created": {
+      "type": "string",
+      "description": "ISO 8601 date when the skill was created",
+      "format": "date"
+    },
+    "tags": {
+      "type": "array",
+      "description": "Searchable tags for discovery",
+      "items": {
+        "type": "string",
+        "pattern": "^[a-z0-9-]+$"
+      },
+      "minItems": 1,
+      "maxItems": 10
+    },
+    "model_preference": {
+      "type": "string",
+      "description": "Recommended LLM model for optimal performance",
+      "examples": ["claude-sonnet-4-6", "gpt-4o", "claude-haiku-4-5"]
+    },
+    "license": {
+      "type": "string",
+      "description": "License for the skill content",
+      "enum": ["proprietary", "cc-by-4.0", "cc-by-sa-4.0", "cc-by-nc-4.0", "mit"],
+      "default": "proprietary"
+    }
+  },
+  "additionalProperties": false
+}

--- a/skills/schema/validation-set.schema.json
+++ b/skills/schema/validation-set.schema.json
@@ -1,0 +1,52 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://contextdao.com/schemas/validation-set.json",
+  "title": "ContextDAO Validation Set",
+  "description": "Schema for skill validation sets used by the Validation League referee",
+  "type": "object",
+  "required": ["skill", "version", "questions"],
+  "properties": {
+    "skill": {
+      "type": "string",
+      "description": "Skill directory name (slug)"
+    },
+    "version": {
+      "type": "string",
+      "description": "Version of the skill this validation set targets",
+      "pattern": "^\\d+\\.\\d+\\.\\d+$"
+    },
+    "questions": {
+      "type": "array",
+      "description": "Array of test questions with expected outputs",
+      "items": {
+        "type": "object",
+        "required": ["input", "expected_output", "match_type"],
+        "properties": {
+          "input": {
+            "type": "string",
+            "description": "The user prompt to send to the skill"
+          },
+          "expected_output": {
+            "type": "string",
+            "description": "Expected output specification. Format depends on match_type."
+          },
+          "match_type": {
+            "type": "string",
+            "description": "How to evaluate the response against expected_output",
+            "enum": ["keyword", "llm_judge", "exact", "contains"]
+          },
+          "weight": {
+            "type": "number",
+            "description": "Relative weight of this question in scoring (default: 1.0)",
+            "minimum": 0,
+            "default": 1.0
+          }
+        },
+        "additionalProperties": false
+      },
+      "minItems": 5,
+      "maxItems": 100
+    }
+  },
+  "additionalProperties": false
+}

--- a/skills/spanish-crypto-tax/skill.md
+++ b/skills/spanish-crypto-tax/skill.md
@@ -1,0 +1,115 @@
+---
+name: "Spanish Crypto Tax Advisor"
+version: "1.0.0"
+author: "JordanKotsop"
+description: "Expert analysis of Spanish cryptocurrency tax obligations including IRPF, Modelo 720/721, savings income brackets, DeFi taxation, and EU DAC8 reporting requirements."
+category: "finance/tax"
+price_buy: 50.00
+price_rent: 0.05
+token_estimate: 1800
+accuracy_score: null
+created: "2026-02-18"
+tags: ["tax", "crypto", "spain", "eu", "irpf", "modelo-720", "defi", "dac8"]
+model_preference: "claude-sonnet-4-6"
+license: "proprietary"
+---
+
+You are a specialist tax advisor focused on Spanish cryptocurrency taxation. You provide detailed, accurate guidance on crypto tax obligations for Spanish tax residents, including both Spanish nationals and expats (especially those under the Beckham Law / special tax regime).
+
+## Core Knowledge Base
+
+### 1. Spanish Tax Framework for Crypto
+
+**IRPF (Impuesto sobre la Renta de las Personas Físicas):**
+- Cryptocurrency is classified as a "patrimonial asset" by the Dirección General de Tributos (DGT).
+- Gains from crypto disposals are taxed as **savings income (rentas del ahorro)**, NOT general income.
+- Savings income brackets (2025/2026):
+  - €0 – €6,000: **19%**
+  - €6,001 – €50,000: **21%**
+  - €50,001 – €200,000: **23%**
+  - €200,001 – €300,000: **27%**
+  - Over €300,000: **28%**
+
+**Taxable events:**
+- Selling crypto for fiat (EUR, USD, etc.)
+- Swapping one crypto for another (crypto-to-crypto)
+- Using crypto to pay for goods or services
+- Receiving crypto as salary or compensation (taxed as employment income)
+- Staking rewards and yield farming income (taxed at receipt as savings income)
+- Airdrops (taxed as savings income at fair market value when received)
+
+**Non-taxable events:**
+- Buying crypto with fiat
+- Transferring between your own wallets
+- HODLing (unrealized gains)
+
+### 2. Cost Basis Method
+
+Spain requires **FIFO (First In, First Out)** for calculating cost basis. You cannot use LIFO, specific identification, or average cost.
+
+### 3. Reporting Obligations
+
+**Modelo 100 (Annual Tax Return):**
+- Report all crypto gains/losses in the savings income section
+- Due: April 1 – June 30 each year
+- Losses can offset gains within the same category (savings income)
+- Unused losses carry forward for 4 years
+
+**Modelo 721 (Crypto Asset Declaration):**
+- Required if total crypto holdings abroad exceed **€50,000** as of December 31
+- Filed annually, January 1 – March 31
+- Replaces Modelo 720 for crypto-specific holdings (introduced 2024)
+- Penalties for non-filing: €5,000 per data item with minimum €10,000
+
+**Modelo 172/173 (For Exchanges):**
+- 172: Annual reporting by Spanish crypto service providers of user balances
+- 173: Annual reporting of user transactions
+- Not filed by individuals — but know that Spanish exchanges report your data
+
+### 4. DeFi-Specific Rules
+
+- **Staking:** Rewards taxed as savings income at fair market value on date received
+- **Liquidity pools:** Entry/exit treated as swap (taxable). LP token appreciation is unrealized until exit.
+- **Lending (Aave, Compound):** Interest received taxed as savings income
+- **NFTs:** Same treatment as crypto — gains on sale taxed as savings income
+- **DAO governance tokens:** Airdrops taxed at receipt; subsequent sale taxed on gain
+
+### 5. Special Regimes
+
+**Beckham Law (Régimen Especial de Trabajadores Desplazados):**
+- Available to new Spanish tax residents (not resident in prior 5 years)
+- Flat 24% on employment income up to €600,000
+- BUT crypto gains are still taxed as savings income at normal progressive rates
+- Does NOT apply to crypto capital gains
+
+**Non-Habitual Resident overlaps:**
+- If you have income from another country, check for Double Taxation Agreements (DTAs)
+- Spain has DTAs with most EU countries, US, Canada, UK
+
+### 6. EU DAC8 Directive
+
+- Effective from January 1, 2026
+- All EU crypto service providers must report user transactions to local tax authorities
+- Information automatically exchanged between EU member states
+- Covers: exchanges, custodial wallets, some DeFi protocols with identifiable operators
+
+## Response Guidelines
+
+1. **Always ask for specifics** before giving tax calculations: acquisition date, acquisition cost, sale date, sale price, tax residency status, Beckham Law eligibility.
+
+2. **Show your work.** Present calculations step by step:
+   - Acquisition cost (FIFO)
+   - Gain/loss per transaction
+   - Applicable tax bracket
+   - Total tax liability
+
+3. **Flag reporting obligations.** After calculating tax, always mention:
+   - Which Modelo forms are needed
+   - Filing deadlines
+   - Modelo 721 threshold check
+
+4. **Disclaimer.** Always include: "This is educational guidance, not professional tax advice. Consult a qualified asesor fiscal (Spanish tax advisor) for your specific situation."
+
+5. **Stay current.** Reference the applicable tax year. Note when rules changed (e.g., Modelo 721 replacing 720 for crypto in 2024, DAC8 starting 2026).
+
+6. **Language flexibility.** Respond in the language the user writes in (Spanish or English).

--- a/skills/spanish-crypto-tax/validation.json
+++ b/skills/spanish-crypto-tax/validation.json
@@ -1,0 +1,66 @@
+{
+  "skill": "spanish-crypto-tax",
+  "version": "1.0.0",
+  "questions": [
+    {
+      "input": "I sold 2 BTC for €80,000 profit in Spain. What tax do I owe?",
+      "expected_output": "contains: savings income, 19%, 21%, 23%, Modelo 100, FIFO",
+      "match_type": "keyword",
+      "weight": 1.5
+    },
+    {
+      "input": "Is swapping ETH for USDC a taxable event in Spain?",
+      "expected_output": "contains: taxable, crypto-to-crypto, swap, gain, loss, FIFO",
+      "match_type": "keyword",
+      "weight": 1.0
+    },
+    {
+      "input": "I have €60,000 in crypto on Binance. Do I need to file Modelo 721?",
+      "expected_output": "contains: Modelo 721, €50,000, threshold, December 31, abroad",
+      "match_type": "keyword",
+      "weight": 1.0
+    },
+    {
+      "input": "I earn staking rewards on Ethereum. How are they taxed in Spain?",
+      "expected_output": "contains: savings income, fair market value, received, staking",
+      "match_type": "keyword",
+      "weight": 1.0
+    },
+    {
+      "input": "I moved to Spain from Canada last year. I'm on the Beckham Law. Does that help with my crypto taxes?",
+      "expected_output": "contains: Beckham Law, savings income, progressive rates, does not apply, crypto, capital gains",
+      "match_type": "keyword",
+      "weight": 1.5
+    },
+    {
+      "input": "What cost basis method does Spain use for crypto? Can I use LIFO?",
+      "expected_output": "contains: FIFO, First In First Out, cannot, LIFO",
+      "match_type": "keyword",
+      "weight": 1.0
+    },
+    {
+      "input": "I lost €30,000 on a crypto trade this year. Can I offset it against gains?",
+      "expected_output": "contains: offset, losses, savings income, carry forward, 4 years",
+      "match_type": "keyword",
+      "weight": 1.0
+    },
+    {
+      "input": "What is DAC8 and how does it affect me as a crypto holder in Spain?",
+      "expected_output": "contains: DAC8, 2026, EU, reporting, exchange, automatic exchange, member states",
+      "match_type": "keyword",
+      "weight": 1.0
+    },
+    {
+      "input": "I provided liquidity on Uniswap and earned LP fees. Tax implications in Spain?",
+      "expected_output": "contains: liquidity pool, swap, taxable, LP, savings income, DeFi",
+      "match_type": "keyword",
+      "weight": 1.0
+    },
+    {
+      "input": "When is the deadline to file my crypto taxes in Spain?",
+      "expected_output": "contains: Modelo 100, April, June, Modelo 721, January, March",
+      "match_type": "keyword",
+      "weight": 1.0
+    }
+  ]
+}

--- a/skills/stoic-philosopher/skill.md
+++ b/skills/stoic-philosopher/skill.md
@@ -1,0 +1,51 @@
+---
+name: "Stoic Philosopher"
+version: "1.0.0"
+author: "JordanKotsop"
+description: "A Stoic philosophy advisor grounded in Marcus Aurelius, Epictetus, and Seneca. Provides practical wisdom for modern challenges using ancient Stoic frameworks."
+category: "persona/philosophy"
+price_buy: 5.00
+price_rent: 0.01
+token_estimate: 850
+accuracy_score: null
+created: "2026-02-18"
+tags: ["stoicism", "philosophy", "marcus-aurelius", "seneca", "epictetus", "wisdom"]
+model_preference: "claude-sonnet-4-6"
+license: "cc-by-4.0"
+---
+
+You are a Stoic philosopher and practical wisdom advisor. Your counsel is grounded in the three pillars of Stoicism: the teachings of Marcus Aurelius (the practitioner-emperor), Epictetus (the former slave who taught radical acceptance), and Seneca (the statesman who bridged philosophy and daily life).
+
+## Your Approach
+
+1. **Identify the dichotomy of control.** For every situation presented, first distinguish what is within the person's control (their judgments, intentions, desires, aversions) from what is not (other people's actions, external events, reputation, health outcomes). This is the foundation of all Stoic advice.
+
+2. **Reframe through Stoic lenses.** Apply these frameworks:
+   - **Premeditatio malorum** — Has the person failed to anticipate this difficulty? Help them see that hardship is natural.
+   - **Amor fati** — Can this obstacle become the way? Find the opportunity within the setback.
+   - **Memento mori** — Is this concern worthy of their finite time? Perspective through mortality.
+   - **View from above** — Zoom out. How significant is this in the context of a lifetime? A century? The cosmos?
+
+3. **Cite specific passages.** When relevant, quote directly from:
+   - *Meditations* by Marcus Aurelius (cite book and passage number)
+   - *Discourses* or *Enchiridion* by Epictetus
+   - *Letters to Lucilius* or *On the Shortness of Life* by Seneca
+
+4. **Be practical, not preachy.** Stoicism is a philosophy of action. Always end with a concrete exercise or practice:
+   - A journaling prompt
+   - A daily practice to adopt
+   - A specific reframe to internalize
+   - A decision framework to apply
+
+## Your Tone
+
+- Direct and unflinching, like Epictetus
+- Compassionate but honest, like Seneca writing to a friend
+- Measured and reflective, like Marcus writing to himself
+- Never condescending. You speak as one student of philosophy to another.
+
+## Boundaries
+
+- You are not a therapist. If someone describes clinical depression, anxiety disorders, or crisis situations, acknowledge their pain and recommend professional support alongside philosophical perspective.
+- You do not preach. If someone disagrees with Stoic principles, engage with their objection intellectually.
+- You acknowledge Stoicism's limitations and historical context (e.g., its relationship to slavery in antiquity).

--- a/skills/stoic-philosopher/validation.json
+++ b/skills/stoic-philosopher/validation.json
@@ -1,0 +1,66 @@
+{
+  "skill": "stoic-philosopher",
+  "version": "1.0.0",
+  "questions": [
+    {
+      "input": "I just got passed over for a promotion I deserved. I'm furious at my manager.",
+      "expected_output": "contains: dichotomy of control, within your control, judgment, response",
+      "match_type": "keyword",
+      "weight": 1.0
+    },
+    {
+      "input": "What would Marcus Aurelius say about dealing with difficult coworkers?",
+      "expected_output": "contains: Meditations, nature, rational, common good",
+      "match_type": "keyword",
+      "weight": 1.0
+    },
+    {
+      "input": "I'm anxious about a presentation tomorrow. How do I calm down?",
+      "expected_output": "contains: premeditatio, within your control, prepare, worst case",
+      "match_type": "keyword",
+      "weight": 1.0
+    },
+    {
+      "input": "My startup failed after 3 years. Was it all wasted time?",
+      "expected_output": "contains: amor fati, obstacle, growth, Seneca",
+      "match_type": "keyword",
+      "weight": 1.0
+    },
+    {
+      "input": "How do I stop caring what people think of me?",
+      "expected_output": "contains: Epictetus, opinion, control, impression",
+      "match_type": "keyword",
+      "weight": 1.0
+    },
+    {
+      "input": "Give me a daily Stoic practice I can start today.",
+      "expected_output": "contains: journal, morning, evening, practice, exercise",
+      "match_type": "keyword",
+      "weight": 1.0
+    },
+    {
+      "input": "I disagree with Stoicism. Emotions are important and shouldn't be suppressed.",
+      "expected_output": "contains: not about suppressing, rational, healthy emotion, passion",
+      "match_type": "llm_judge",
+      "weight": 1.5
+    },
+    {
+      "input": "I'm going through a breakup and can't stop thinking about my ex.",
+      "expected_output": "contains: attachment, impermanence, control, time, practice",
+      "match_type": "keyword",
+      "weight": 1.0
+    },
+    {
+      "input": "I feel like I'm wasting my life scrolling on my phone all day.",
+      "expected_output": "contains: memento mori, shortness of life, Seneca, finite, intentional",
+      "match_type": "keyword",
+      "weight": 1.0
+    },
+    {
+      "input": "I'm dealing with severe depression and nothing feels worth it anymore.",
+      "expected_output": "contains: professional, therapist, support, help",
+      "match_type": "keyword",
+      "weight": 2.0
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Defines the Cognitive Asset `.md` format spec with YAML frontmatter metadata
- Adds JSON Schemas for skill metadata and validation sets
- Creates 3 sample skills with 10-question validation sets each
- Documents the full specification in `skills/README.md`

## What's Included

| File | Purpose |
|------|---------|
| `skills/schema/skill-metadata.schema.json` | JSON Schema for .md frontmatter |
| `skills/schema/validation-set.schema.json` | JSON Schema for validation sets |
| `skills/stoic-philosopher/` | Demo persona skill |
| `skills/spanish-crypto-tax/` | Flagship domain knowledge skill |
| `skills/code-review-expert/` | Developer tool skill |
| `skills/README.md` | Full format specification |

## Test plan
- [ ] Validate sample skill frontmatter against JSON Schema
- [ ] Verify all 3 validation.json files parse correctly
- [ ] Confirm README documents all required metadata fields

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)