### PR TITLE
feat(marketplace): Skill Registry & Marketplace UI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "clsx": "^2.1.0",
         "framer-motion": "^12.27.1",
+        "gray-matter": "^4.0.3",
         "next": "^15.0.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
@@ -3027,6 +3028,19 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "license": "BSD-2-Clause",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/esquery": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
@@ -3069,6 +3083,18 @@
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/extend-shallow": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+      "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
+      "license": "MIT",
+      "dependencies": {
+        "is-extendable": "^0.1.0"
+      },
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3447,6 +3473,43 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/gray-matter": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/gray-matter/-/gray-matter-4.0.3.tgz",
+      "integrity": "sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-yaml": "^3.13.1",
+        "kind-of": "^6.0.2",
+        "section-matter": "^1.0.0",
+        "strip-bom-string": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=6.0"
+      }
+    },
+    "node_modules/gray-matter/node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/gray-matter/node_modules/js-yaml": {
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
+      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
     "node_modules/has-bigints": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
@@ -3749,6 +3812,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-extendable": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/is-extglob": {
@@ -4128,6 +4200,15 @@
       "license": "MIT",
       "dependencies": {
         "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/kind-of": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/language-subtag-registry": {
@@ -5187,6 +5268,19 @@
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
       "license": "MIT"
     },
+    "node_modules/section-matter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/section-matter/-/section-matter-1.0.0.tgz",
+      "integrity": "sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==",
+      "license": "MIT",
+      "dependencies": {
+        "extend-shallow": "^2.0.1",
+        "kind-of": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/semver": {
       "version": "7.7.3",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
@@ -5402,6 +5496,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/stable-hash": {
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/stable-hash/-/stable-hash-0.0.5.tgz",
@@ -5544,6 +5644,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/strip-bom-string": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom-string/-/strip-bom-string-1.0.0.tgz",
+      "integrity": "sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/strip-json-comments": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "clsx": "^2.1.0",
     "framer-motion": "^12.27.1",
+    "gray-matter": "^4.0.3",
     "next": "^15.0.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",

--- a/src/app/api/skills/[slug]/route.ts
+++ b/src/app/api/skills/[slug]/route.ts
@@ -1,0 +1,22 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getSkillBySlug } from "@/lib/skills";
+
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ slug: string }> }
+) {
+  const { slug } = await params;
+  const skill = getSkillBySlug(slug);
+
+  if (!skill) {
+    return NextResponse.json({ error: "Skill not found" }, { status: 404 });
+  }
+
+  // Don't expose full content in API — that's what x402 is for
+  return NextResponse.json({
+    slug: skill.slug,
+    metadata: skill.metadata,
+    content_preview: skill.content.slice(0, 200) + "...",
+    content_length: skill.content.length,
+  });
+}

--- a/src/app/api/skills/route.ts
+++ b/src/app/api/skills/route.ts
@@ -1,0 +1,13 @@
+import { NextRequest, NextResponse } from "next/server";
+import { searchSkills } from "@/lib/skills";
+
+export async function GET(request: NextRequest) {
+  const { searchParams } = request.nextUrl;
+  const query = searchParams.get("q") ?? "";
+  const category = searchParams.get("category") ?? undefined;
+  const sortBy = (searchParams.get("sort") as "newest" | "price_low" | "price_high" | "accuracy") ?? undefined;
+
+  const skills = searchSkills(query, category, sortBy);
+
+  return NextResponse.json({ skills, total: skills.length });
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -8,8 +8,8 @@ const inter = Inter({
 })
 
 export const metadata: Metadata = {
-  title: 'Masterclass App',
-  description: 'Built with Claude Code at the Barcelona Masterclass',
+  title: 'ContextDAO — Cognitive Asset Marketplace',
+  description: 'Trade, rent, and optimize high-performance system prompts via x402 payment protocol',
 }
 
 export default function RootLayout({

--- a/src/app/marketplace/[slug]/page.tsx
+++ b/src/app/marketplace/[slug]/page.tsx
@@ -1,0 +1,169 @@
+import { notFound } from "next/navigation";
+import Link from "next/link";
+import { getAllSkills, getSkillBySlug } from "@/lib/skills";
+import { AccuracyBadge } from "@/components/marketplace/accuracy-badge";
+import { PricingTable } from "@/components/marketplace/pricing-table";
+
+interface SkillDetailPageProps {
+  params: Promise<{ slug: string }>;
+}
+
+export async function generateStaticParams() {
+  const skills = getAllSkills();
+  return skills.map((s) => ({ slug: s.slug }));
+}
+
+export async function generateMetadata({ params }: SkillDetailPageProps) {
+  const { slug } = await params;
+  const skill = getSkillBySlug(slug);
+  if (!skill) return { title: "Not Found — ContextDAO" };
+  return {
+    title: `${skill.metadata.name} — ContextDAO`,
+    description: skill.metadata.description,
+  };
+}
+
+export default async function SkillDetailPage({
+  params,
+}: SkillDetailPageProps) {
+  const { slug } = await params;
+  const skill = getSkillBySlug(slug);
+
+  if (!skill) notFound();
+
+  const { metadata } = skill;
+  const categoryParts = metadata.category.split("/");
+
+  return (
+    <div className="min-h-screen bg-black text-white">
+      {/* Header */}
+      <header className="flex items-center justify-between border-b border-white/5 px-6 py-4 md:px-12">
+        <Link
+          href="/"
+          className="flex items-center gap-3 transition-opacity hover:opacity-80"
+        >
+          <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-lime">
+            <span className="text-sm font-bold text-black">CD</span>
+          </div>
+          <span className="hidden text-sm font-medium text-white/70 sm:block">
+            ContextDAO
+          </span>
+        </Link>
+        <nav className="flex items-center gap-6 text-sm text-white/50">
+          <Link
+            href="/marketplace"
+            className="transition-colors hover:text-white/80"
+          >
+            Marketplace
+          </Link>
+          <Link href="/" className="transition-colors hover:text-white/80">
+            Home
+          </Link>
+        </nav>
+      </header>
+
+      {/* Content */}
+      <main className="mx-auto max-w-4xl px-6 py-12 md:px-12">
+        {/* Breadcrumb */}
+        <div className="mb-8 flex items-center gap-2 text-sm text-white/40">
+          <Link
+            href="/marketplace"
+            className="transition-colors hover:text-white/60"
+          >
+            Marketplace
+          </Link>
+          <span>/</span>
+          <span className="text-white/60">{metadata.name}</span>
+        </div>
+
+        {/* Title section */}
+        <div className="mb-8">
+          <div className="mb-3 flex flex-wrap items-center gap-3">
+            <span className="rounded-lg bg-white/5 px-2.5 py-1 text-xs text-white/50">
+              {categoryParts.join(" / ")}
+            </span>
+            <AccuracyBadge score={metadata.accuracy_score} size="md" />
+            <span className="text-xs text-white/30">v{metadata.version}</span>
+          </div>
+          <h1 className="mb-3 text-4xl font-bold">{metadata.name}</h1>
+          <p className="max-w-2xl text-lg text-white/60">
+            {metadata.description}
+          </p>
+        </div>
+
+        {/* Meta row */}
+        <div className="mb-10 flex flex-wrap items-center gap-6 text-sm text-white/40">
+          <div className="flex items-center gap-2">
+            <span className="text-white/60">Author:</span>
+            <span className="text-white">{metadata.author}</span>
+          </div>
+          <div className="flex items-center gap-2">
+            <span className="text-white/60">Tokens:</span>
+            <span className="text-white">~{metadata.token_estimate}</span>
+          </div>
+          <div className="flex items-center gap-2">
+            <span className="text-white/60">Created:</span>
+            <span className="text-white">{metadata.created}</span>
+          </div>
+          {metadata.model_preference && (
+            <div className="flex items-center gap-2">
+              <span className="text-white/60">Best with:</span>
+              <span className="font-mono text-xs text-lime">
+                {metadata.model_preference}
+              </span>
+            </div>
+          )}
+        </div>
+
+        {/* Pricing */}
+        <section className="mb-10">
+          <h2 className="mb-4 text-xl font-semibold">Pricing</h2>
+          <PricingTable metadata={metadata} />
+        </section>
+
+        {/* Tags */}
+        <section className="mb-10">
+          <h2 className="mb-4 text-xl font-semibold">Tags</h2>
+          <div className="flex flex-wrap gap-2">
+            {metadata.tags.map((tag) => (
+              <Link
+                key={tag}
+                href={`/marketplace?q=${tag}`}
+                className="rounded-lg border border-white/10 bg-white/5 px-3 py-1.5 text-sm text-white/60 transition-colors hover:border-lime/30 hover:text-lime"
+              >
+                {tag}
+              </Link>
+            ))}
+          </div>
+        </section>
+
+        {/* Content preview */}
+        <section className="mb-10">
+          <h2 className="mb-4 text-xl font-semibold">Prompt Preview</h2>
+          <div className="relative overflow-hidden rounded-2xl border border-white/10 bg-white/[0.02] p-6">
+            <pre className="whitespace-pre-wrap font-mono text-sm leading-relaxed text-white/50">
+              {skill.content.slice(0, 500)}
+            </pre>
+            {skill.content.length > 500 && (
+              <div className="absolute inset-x-0 bottom-0 h-24 bg-gradient-to-t from-black to-transparent" />
+            )}
+            {skill.content.length > 500 && (
+              <div className="absolute bottom-4 left-0 right-0 text-center">
+                <span className="rounded-full border border-lime/30 bg-black px-4 py-1.5 text-xs text-lime">
+                  Buy to see full prompt ({skill.content.length} chars)
+                </span>
+              </div>
+            )}
+          </div>
+        </section>
+
+        {/* License */}
+        {metadata.license && (
+          <section className="border-t border-white/5 pt-6 text-sm text-white/30">
+            License: {metadata.license}
+          </section>
+        )}
+      </main>
+    </div>
+  );
+}

--- a/src/app/marketplace/page.tsx
+++ b/src/app/marketplace/page.tsx
@@ -1,0 +1,96 @@
+import { Suspense } from "react";
+import Link from "next/link";
+import { searchSkills } from "@/lib/skills";
+import { SkillCard } from "@/components/marketplace/skill-card";
+import { SearchBar } from "@/components/marketplace/search-bar";
+
+interface MarketplacePageProps {
+  searchParams: Promise<{
+    q?: string;
+    category?: string;
+    sort?: string;
+  }>;
+}
+
+export const metadata = {
+  title: "Marketplace — ContextDAO",
+  description: "Browse, search, and acquire cognitive assets",
+};
+
+export default async function MarketplacePage({
+  searchParams,
+}: MarketplacePageProps) {
+  const params = await searchParams;
+  const skills = searchSkills(
+    params.q ?? "",
+    params.category ?? undefined,
+    (params.sort as "newest" | "price_low" | "price_high" | "accuracy") ??
+      undefined
+  );
+
+  return (
+    <div className="min-h-screen bg-black text-white">
+      {/* Header */}
+      <header className="flex items-center justify-between border-b border-white/5 px-6 py-4 md:px-12">
+        <Link
+          href="/"
+          className="flex items-center gap-3 transition-opacity hover:opacity-80"
+        >
+          <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-lime">
+            <span className="text-sm font-bold text-black">CD</span>
+          </div>
+          <span className="hidden text-sm font-medium text-white/70 sm:block">
+            ContextDAO
+          </span>
+        </Link>
+        <nav className="flex items-center gap-6 text-sm text-white/50">
+          <span className="text-white">Marketplace</span>
+          <Link href="/" className="transition-colors hover:text-white/80">
+            Home
+          </Link>
+        </nav>
+      </header>
+
+      {/* Content */}
+      <main className="mx-auto max-w-6xl px-6 py-12 md:px-12">
+        {/* Title */}
+        <div className="mb-8">
+          <h1 className="mb-2 text-3xl font-bold">Cognitive Assets</h1>
+          <p className="text-white/50">
+            Browse high-performance system prompts. Buy for source access or
+            rent for blind inference.
+          </p>
+        </div>
+
+        {/* Search & filters */}
+        <div className="mb-8">
+          <Suspense fallback={null}>
+            <SearchBar />
+          </Suspense>
+        </div>
+
+        {/* Results count */}
+        <div className="mb-6 text-sm text-white/40">
+          {skills.length} skill{skills.length !== 1 ? "s" : ""} available
+        </div>
+
+        {/* Grid */}
+        {skills.length > 0 ? (
+          <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+            {skills.map((skill) => (
+              <SkillCard key={skill.slug} skill={skill} />
+            ))}
+          </div>
+        ) : (
+          <div className="flex flex-col items-center justify-center rounded-2xl border border-dashed border-white/10 py-20 text-center">
+            <div className="mb-3 text-4xl">&#128270;</div>
+            <p className="text-white/50">No skills found</p>
+            <p className="text-sm text-white/30">
+              Try adjusting your search or filters
+            </p>
+          </div>
+        )}
+      </main>
+    </div>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -146,8 +146,8 @@ export default function HomePage() {
               transition={{ duration: 0.5, delay: 0.3 }}
               className="flex flex-wrap items-center gap-4"
             >
-              <MagneticButton href="https://docs.anthropic.com/en/docs/claude-code">
-                Open Claude Code docs
+              <MagneticButton href="/marketplace">
+                Browse Marketplace
               </MagneticButton>
             </motion.div>
             <motion.p
@@ -156,11 +156,11 @@ export default function HomePage() {
               transition={{ duration: 0.5, delay: 0.4 }}
               className="text-white/40 text-sm"
             >
-              or type{" "}
+              or integrate via{" "}
               <code className="px-2 py-1 bg-white/10 rounded-lg text-lime font-mono text-xs">
-                claude
+                MCP
               </code>{" "}
-              in terminal to get started
+              for agent-native access
             </motion.p>
           </div>
 

--- a/src/components/marketplace/accuracy-badge.tsx
+++ b/src/components/marketplace/accuracy-badge.tsx
@@ -1,0 +1,40 @@
+import { cn } from "@/lib/utils";
+
+interface AccuracyBadgeProps {
+  score: number | null;
+  size?: "sm" | "md";
+}
+
+export function AccuracyBadge({ score, size = "sm" }: AccuracyBadgeProps) {
+  if (score === null) {
+    return (
+      <span
+        className={cn(
+          "inline-flex items-center gap-1 rounded-full border border-white/10 bg-white/5 text-white/40",
+          size === "sm" ? "px-2 py-0.5 text-xs" : "px-3 py-1 text-sm"
+        )}
+      >
+        Unvalidated
+      </span>
+    );
+  }
+
+  const color =
+    score >= 80
+      ? "text-lime border-lime/30 bg-lime/10"
+      : score >= 60
+        ? "text-yellow-400 border-yellow-400/30 bg-yellow-400/10"
+        : "text-red-400 border-red-400/30 bg-red-400/10";
+
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center gap-1 rounded-full border font-medium",
+        color,
+        size === "sm" ? "px-2 py-0.5 text-xs" : "px-3 py-1 text-sm"
+      )}
+    >
+      {score}%
+    </span>
+  );
+}

--- a/src/components/marketplace/pricing-table.tsx
+++ b/src/components/marketplace/pricing-table.tsx
@@ -1,0 +1,67 @@
+import type { SkillMetadata } from "@/lib/skills";
+
+interface PricingTableProps {
+  metadata: SkillMetadata;
+}
+
+export function PricingTable({ metadata }: PricingTableProps) {
+  return (
+    <div className="grid gap-4 sm:grid-cols-2">
+      {/* Buy option */}
+      <div className="rounded-2xl border border-lime/20 bg-lime/5 p-6">
+        <div className="mb-1 text-sm font-medium uppercase tracking-wider text-lime/60">
+          Buy — Source Access
+        </div>
+        <div className="mb-3 text-3xl font-bold text-white">
+          ${metadata.price_buy}
+          <span className="text-base font-normal text-white/40"> one-time</span>
+        </div>
+        <ul className="mb-6 space-y-2 text-sm text-white/60">
+          <li className="flex items-center gap-2">
+            <span className="text-lime">&#10003;</span>
+            Full .md source file download
+          </li>
+          <li className="flex items-center gap-2">
+            <span className="text-lime">&#10003;</span>
+            Run locally — no per-call fees
+          </li>
+          <li className="flex items-center gap-2">
+            <span className="text-lime">&#10003;</span>
+            Modify and customize freely
+          </li>
+        </ul>
+        <button className="w-full rounded-xl bg-lime py-2.5 text-sm font-semibold text-black transition-colors hover:bg-lime-hover">
+          Buy via x402
+        </button>
+      </div>
+
+      {/* Rent option */}
+      <div className="rounded-2xl border border-white/10 bg-white/[0.02] p-6">
+        <div className="mb-1 text-sm font-medium uppercase tracking-wider text-white/40">
+          Rent — Blind Inference
+        </div>
+        <div className="mb-3 text-3xl font-bold text-white">
+          ${metadata.price_rent}
+          <span className="text-base font-normal text-white/40"> per call</span>
+        </div>
+        <ul className="mb-6 space-y-2 text-sm text-white/60">
+          <li className="flex items-center gap-2">
+            <span className="text-white/40">&#10003;</span>
+            Send prompt, get result — IP hidden
+          </li>
+          <li className="flex items-center gap-2">
+            <span className="text-white/40">&#10003;</span>
+            Pay only for what you use
+          </li>
+          <li className="flex items-center gap-2">
+            <span className="text-white/40">&#10003;</span>
+            ~{metadata.token_estimate} tokens per call
+          </li>
+        </ul>
+        <button className="w-full rounded-xl border border-white/20 bg-white/5 py-2.5 text-sm font-semibold text-white transition-colors hover:border-white/30 hover:bg-white/10">
+          Rent via x402
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/marketplace/search-bar.tsx
+++ b/src/components/marketplace/search-bar.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+import { useRouter, useSearchParams } from "next/navigation";
+import { useCallback, useState, useTransition } from "react";
+
+const CATEGORIES = [
+  { value: "", label: "All Categories" },
+  { value: "finance", label: "Finance" },
+  { value: "development", label: "Development" },
+  { value: "persona", label: "Persona" },
+  { value: "data", label: "Data" },
+  { value: "legal", label: "Legal" },
+  { value: "writing", label: "Writing" },
+];
+
+const SORT_OPTIONS = [
+  { value: "newest", label: "Newest" },
+  { value: "price_low", label: "Price: Low" },
+  { value: "price_high", label: "Price: High" },
+  { value: "accuracy", label: "Accuracy" },
+];
+
+export function SearchBar() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const [isPending, startTransition] = useTransition();
+
+  const [query, setQuery] = useState(searchParams.get("q") ?? "");
+  const currentCategory = searchParams.get("category") ?? "";
+  const currentSort = searchParams.get("sort") ?? "newest";
+
+  const updateParams = useCallback(
+    (updates: Record<string, string>) => {
+      const params = new URLSearchParams(searchParams.toString());
+      for (const [key, value] of Object.entries(updates)) {
+        if (value) {
+          params.set(key, value);
+        } else {
+          params.delete(key);
+        }
+      }
+      startTransition(() => {
+        router.push(`/marketplace?${params.toString()}`);
+      });
+    },
+    [router, searchParams]
+  );
+
+  return (
+    <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+      {/* Search input */}
+      <div className="relative flex-1">
+        <svg
+          className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-white/30"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+          strokeWidth={2}
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
+          />
+        </svg>
+        <input
+          type="text"
+          placeholder="Search skills..."
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") updateParams({ q: query });
+          }}
+          className="w-full rounded-xl border border-white/10 bg-white/5 py-2.5 pl-10 pr-4 text-sm text-white placeholder-white/30 transition-colors focus:border-lime/50 focus:outline-none"
+        />
+        {isPending && (
+          <div className="absolute right-3 top-1/2 h-4 w-4 -translate-y-1/2 animate-spin rounded-full border-2 border-lime/30 border-t-lime" />
+        )}
+      </div>
+
+      {/* Category filter */}
+      <select
+        value={currentCategory}
+        onChange={(e) => updateParams({ category: e.target.value })}
+        className="rounded-xl border border-white/10 bg-white/5 px-3 py-2.5 text-sm text-white/80 transition-colors focus:border-lime/50 focus:outline-none"
+      >
+        {CATEGORIES.map((c) => (
+          <option key={c.value} value={c.value} className="bg-zinc-900">
+            {c.label}
+          </option>
+        ))}
+      </select>
+
+      {/* Sort */}
+      <select
+        value={currentSort}
+        onChange={(e) => updateParams({ sort: e.target.value })}
+        className="rounded-xl border border-white/10 bg-white/5 px-3 py-2.5 text-sm text-white/80 transition-colors focus:border-lime/50 focus:outline-none"
+      >
+        {SORT_OPTIONS.map((s) => (
+          <option key={s.value} value={s.value} className="bg-zinc-900">
+            {s.label}
+          </option>
+        ))}
+      </select>
+    </div>
+  );
+}

--- a/src/components/marketplace/skill-card.tsx
+++ b/src/components/marketplace/skill-card.tsx
@@ -1,0 +1,86 @@
+import Link from "next/link";
+import type { SkillSummary } from "@/lib/skills";
+import { AccuracyBadge } from "./accuracy-badge";
+
+interface SkillCardProps {
+  skill: SkillSummary;
+}
+
+const categoryIcons: Record<string, string> = {
+  "finance": "$",
+  "development": ">_",
+  "persona": "@",
+  "data": "#",
+  "legal": "§",
+  "writing": "A",
+};
+
+function getCategoryIcon(category: string): string {
+  const root = category.split("/")[0];
+  return categoryIcons[root] ?? "?";
+}
+
+export function SkillCard({ skill }: SkillCardProps) {
+  const { metadata, slug } = skill;
+
+  return (
+    <Link href={`/marketplace/${slug}`}>
+      <div className="group relative rounded-2xl border border-white/10 bg-white/[0.02] p-6 transition-all hover:border-lime/30 hover:bg-white/[0.04]">
+        {/* Category icon */}
+        <div className="mb-4 flex items-start justify-between">
+          <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-white/5 font-mono text-sm text-white/60 transition-colors group-hover:bg-lime/10 group-hover:text-lime">
+            {getCategoryIcon(metadata.category)}
+          </div>
+          <AccuracyBadge score={metadata.accuracy_score} />
+        </div>
+
+        {/* Name & description */}
+        <h3 className="mb-1 text-lg font-semibold text-white transition-colors group-hover:text-lime">
+          {metadata.name}
+        </h3>
+        <p className="mb-4 line-clamp-2 text-sm text-white/50">
+          {metadata.description}
+        </p>
+
+        {/* Tags */}
+        <div className="mb-4 flex flex-wrap gap-1.5">
+          {metadata.tags.slice(0, 3).map((tag) => (
+            <span
+              key={tag}
+              className="rounded-md bg-white/5 px-2 py-0.5 text-xs text-white/40"
+            >
+              {tag}
+            </span>
+          ))}
+          {metadata.tags.length > 3 && (
+            <span className="text-xs text-white/30">
+              +{metadata.tags.length - 3}
+            </span>
+          )}
+        </div>
+
+        {/* Footer: pricing + meta */}
+        <div className="flex items-center justify-between border-t border-white/5 pt-4">
+          <div className="flex items-center gap-3">
+            <div>
+              <div className="text-sm font-medium text-white">
+                ${metadata.price_buy}
+              </div>
+              <div className="text-xs text-white/40">buy</div>
+            </div>
+            <div className="h-6 w-px bg-white/10" />
+            <div>
+              <div className="text-sm font-medium text-white">
+                ${metadata.price_rent}
+              </div>
+              <div className="text-xs text-white/40">per call</div>
+            </div>
+          </div>
+          <div className="text-xs text-white/30">
+            ~{metadata.token_estimate} tokens
+          </div>
+        </div>
+      </div>
+    </Link>
+  );
+}

--- a/src/lib/skills.ts
+++ b/src/lib/skills.ts
@@ -1,0 +1,119 @@
+import fs from "fs";
+import path from "path";
+import matter from "gray-matter";
+
+export interface SkillMetadata {
+  name: string;
+  version: string;
+  author: string;
+  description: string;
+  category: string;
+  price_buy: number;
+  price_rent: number;
+  token_estimate: number;
+  accuracy_score: number | null;
+  created: string;
+  tags: string[];
+  model_preference?: string;
+  license?: string;
+}
+
+export interface Skill {
+  slug: string;
+  metadata: SkillMetadata;
+  content: string;
+}
+
+export interface SkillSummary {
+  slug: string;
+  metadata: SkillMetadata;
+}
+
+const SKILLS_DIR = path.join(process.cwd(), "skills");
+
+function parseSkillFile(slug: string): Skill | null {
+  const skillPath = path.join(SKILLS_DIR, slug, "skill.md");
+  if (!fs.existsSync(skillPath)) return null;
+
+  const raw = fs.readFileSync(skillPath, "utf-8");
+  const { data, content } = matter(raw);
+
+  return {
+    slug,
+    metadata: data as SkillMetadata,
+    content: content.trim(),
+  };
+}
+
+export function getAllSkills(): SkillSummary[] {
+  if (!fs.existsSync(SKILLS_DIR)) return [];
+
+  const dirs = fs.readdirSync(SKILLS_DIR, { withFileTypes: true });
+
+  return dirs
+    .filter(
+      (d) => d.isDirectory() && d.name !== "schema" && d.name !== "node_modules"
+    )
+    .map((d) => {
+      const skill = parseSkillFile(d.name);
+      if (!skill) return null;
+      return { slug: skill.slug, metadata: skill.metadata };
+    })
+    .filter((s): s is SkillSummary => s !== null)
+    .sort(
+      (a, b) =>
+        new Date(b.metadata.created).getTime() -
+        new Date(a.metadata.created).getTime()
+    );
+}
+
+export function getSkillBySlug(slug: string): Skill | null {
+  return parseSkillFile(slug);
+}
+
+export function searchSkills(
+  query: string,
+  category?: string,
+  sortBy?: "newest" | "price_low" | "price_high" | "accuracy"
+): SkillSummary[] {
+  let results = getAllSkills();
+
+  if (query) {
+    const q = query.toLowerCase();
+    results = results.filter(
+      (s) =>
+        s.metadata.name.toLowerCase().includes(q) ||
+        s.metadata.description.toLowerCase().includes(q) ||
+        s.metadata.tags.some((t) => t.includes(q))
+    );
+  }
+
+  if (category) {
+    results = results.filter((s) => s.metadata.category.startsWith(category));
+  }
+
+  if (sortBy) {
+    switch (sortBy) {
+      case "newest":
+        results.sort(
+          (a, b) =>
+            new Date(b.metadata.created).getTime() -
+            new Date(a.metadata.created).getTime()
+        );
+        break;
+      case "price_low":
+        results.sort((a, b) => a.metadata.price_buy - b.metadata.price_buy);
+        break;
+      case "price_high":
+        results.sort((a, b) => b.metadata.price_buy - a.metadata.price_buy);
+        break;
+      case "accuracy":
+        results.sort(
+          (a, b) => (b.metadata.accuracy_score ?? 0) - (a.metadata.accuracy_score ?? 0)
+        );
+        break;
+    }
+  }
+
+  return results;
+}


### PR DESCRIPTION
## Summary
- Skill loader utility that reads `.md` files from `skills/` and parses YAML frontmatter
- API routes for skill listing (with search, filter, sort) and skill detail
- Marketplace listing page (`/marketplace`) with card grid, search bar, category/sort filters
- Skill detail page (`/marketplace/[slug]`) with pricing table, accuracy badge, content preview
- Landing page updated to link to marketplace

## Components Built
| Component | Purpose |
|-----------|---------|
| `SkillCard` | Preview card with name, category, pricing, accuracy |
| `SearchBar` | Full-text search + category filter + sort |
| `AccuracyBadge` | Color-coded score indicator (lime/yellow/red) |
| `PricingTable` | Buy vs Rent comparison with x402 CTAs |

## Routes
- `/marketplace` — Browse all skills
- `/marketplace/[slug]` — Skill detail (SSG for all 3 sample skills)
- `GET /api/skills?q=&category=&sort=` — Skill listing API
- `GET /api/skills/[slug]` — Skill detail API (content truncated, full access via x402)

## Test plan
- [ ] Visit `/marketplace` — 3 skill cards render
- [ ] Search for "tax" — only Spanish Crypto Tax appears
- [ ] Filter by "development" category — only Code Review Expert appears
- [ ] Click a card — detail page loads with pricing, tags, preview
- [ ] API returns JSON at `/api/skills`
- [ ] Build passes with no errors

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)