### PR TITLE
feat(league): add Validation League

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ Thumbs.db
 
 # Vercel
 .vercel
+
+# League data (runtime state)
+.league-data/

--- a/src/app/api/league/bounties/[id]/route.ts
+++ b/src/app/api/league/bounties/[id]/route.ts
@@ -1,0 +1,27 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getBountyById, getSubmissionsForBounty } from "@/lib/bounty";
+
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  const segments = request.nextUrl.pathname.split("/");
+  const id = segments[segments.length - 1];
+
+  const bounty = getBountyById(id);
+  if (!bounty) {
+    return NextResponse.json({ error: "Bounty not found" }, { status: 404 });
+  }
+
+  const submissions = getSubmissionsForBounty(bounty.id).map((s) => ({
+    id: s.id,
+    optimizer_wallet: s.optimizer_wallet,
+    submitted_at: s.submitted_at,
+    status: s.status,
+    accuracy_delta: s.accuracy_delta,
+    token_delta: s.token_delta,
+    payout: s.payout,
+  }));
+
+  return NextResponse.json({
+    ...bounty,
+    submissions,
+  });
+}

--- a/src/app/api/league/bounties/[id]/submit/route.ts
+++ b/src/app/api/league/bounties/[id]/submit/route.ts
@@ -1,0 +1,156 @@
+import { NextRequest, NextResponse } from "next/server";
+import {
+  getBountyById,
+  createSubmission,
+  updateSubmission,
+  deductBountyPool,
+} from "@/lib/bounty";
+import { getSkillBySlug } from "@/lib/skills";
+import { referee } from "@/lib/referee";
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  const segments = request.nextUrl.pathname.split("/");
+  // URL: /api/league/bounties/[id]/submit → id is at index -2
+  const bountyId = segments[segments.length - 2];
+
+  const bounty = getBountyById(bountyId);
+  if (!bounty) {
+    return NextResponse.json({ error: "Bounty not found" }, { status: 404 });
+  }
+
+  if (bounty.status !== "active") {
+    return NextResponse.json(
+      { error: `Bounty is ${bounty.status}` },
+      { status: 400 }
+    );
+  }
+
+  const body = await request.json().catch(() => null);
+  if (!body) {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const { optimizer_wallet, v2_content } = body;
+
+  if (!optimizer_wallet || !v2_content) {
+    return NextResponse.json(
+      { error: "Missing required fields: optimizer_wallet, v2_content" },
+      { status: 400 }
+    );
+  }
+
+  const skill = getSkillBySlug(bounty.skill_slug);
+  if (!skill) {
+    return NextResponse.json(
+      { error: "Skill not found for this bounty" },
+      { status: 404 }
+    );
+  }
+
+  // Create the submission record
+  const submission = createSubmission({
+    bounty_id: bounty.id,
+    skill_slug: bounty.skill_slug,
+    optimizer_wallet,
+    v2_content,
+  });
+
+  // Check API key before starting evaluation
+  if (!process.env.ANTHROPIC_API_KEY) {
+    updateSubmission(submission.id, { status: "pending" });
+    return NextResponse.json(
+      {
+        submission_id: submission.id,
+        status: "pending",
+        message:
+          "Submission recorded. Evaluation requires ANTHROPIC_API_KEY to be configured.",
+      },
+      { status: 202 }
+    );
+  }
+
+  // Run the referee
+  updateSubmission(submission.id, { status: "evaluating" });
+
+  try {
+    const verdict = await referee(bounty.skill_slug, skill.content, v2_content);
+
+    if (verdict.improved) {
+      // Calculate payout
+      const accuracyReward =
+        Math.max(0, verdict.accuracy_delta) *
+        bounty.reward_per_accuracy_pct;
+      const tokenRewardPct =
+        verdict.v1_score.total_tokens > 0
+          ? (verdict.token_delta / verdict.v1_score.total_tokens) * 100
+          : 0;
+      const tokenReward =
+        Math.max(0, tokenRewardPct) *
+        bounty.reward_per_token_reduction_pct;
+      const totalPayout = Math.min(
+        accuracyReward + tokenReward,
+        bounty.pool_remaining
+      );
+
+      updateSubmission(submission.id, {
+        status: "accepted",
+        accuracy_delta: verdict.accuracy_delta,
+        token_delta: verdict.token_delta,
+        payout: Math.round(totalPayout * 100) / 100,
+        verdict_timestamp: verdict.timestamp,
+      });
+
+      deductBountyPool(bounty.id, totalPayout);
+
+      return NextResponse.json({
+        submission_id: submission.id,
+        status: "accepted",
+        verdict: {
+          v1_accuracy: verdict.v1_score.accuracy_pct,
+          v2_accuracy: verdict.v2_score.accuracy_pct,
+          accuracy_delta: verdict.accuracy_delta,
+          token_delta: verdict.token_delta,
+        },
+        payout: {
+          accuracy_reward: Math.round(accuracyReward * 100) / 100,
+          token_reward: Math.round(tokenReward * 100) / 100,
+          total: Math.round(totalPayout * 100) / 100,
+          currency: "USDC",
+          network: "base-sepolia",
+          payment_method: "x402 (simulated on testnet)",
+        },
+        message: `Improvement confirmed! $${(Math.round(totalPayout * 100) / 100).toFixed(2)} USDC payout queued.`,
+      });
+    } else {
+      updateSubmission(submission.id, {
+        status: "rejected",
+        accuracy_delta: verdict.accuracy_delta,
+        token_delta: verdict.token_delta,
+        payout: 0,
+        verdict_timestamp: verdict.timestamp,
+      });
+
+      return NextResponse.json({
+        submission_id: submission.id,
+        status: "rejected",
+        verdict: {
+          v1_accuracy: verdict.v1_score.accuracy_pct,
+          v2_accuracy: verdict.v2_score.accuracy_pct,
+          accuracy_delta: verdict.accuracy_delta,
+          token_delta: verdict.token_delta,
+        },
+        message: "No improvement detected. Try again with a different approach.",
+      });
+    }
+  } catch (err) {
+    updateSubmission(submission.id, { status: "pending" });
+    return NextResponse.json(
+      {
+        submission_id: submission.id,
+        status: "error",
+        error: err instanceof Error ? err.message : "Evaluation failed",
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/league/bounties/route.ts
+++ b/src/app/api/league/bounties/route.ts
@@ -1,0 +1,72 @@
+import { NextRequest, NextResponse } from "next/server";
+import {
+  getActiveBounties,
+  createBounty,
+} from "@/lib/bounty";
+import { getSkillBySlug } from "@/lib/skills";
+
+export async function GET(): Promise<NextResponse> {
+  const bounties = getActiveBounties();
+
+  return NextResponse.json({
+    count: bounties.length,
+    bounties: bounties.map((b) => ({
+      id: b.id,
+      skill_slug: b.skill_slug,
+      reward_per_accuracy_pct: b.reward_per_accuracy_pct,
+      reward_per_token_reduction_pct: b.reward_per_token_reduction_pct,
+      pool_remaining: b.pool_remaining,
+      max_pool: b.max_pool,
+      expires_at: b.expires_at,
+      status: b.status,
+    })),
+  });
+}
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  const body = await request.json().catch(() => null);
+
+  if (!body) {
+    return NextResponse.json(
+      { error: "Invalid JSON body" },
+      { status: 400 }
+    );
+  }
+
+  const {
+    skill_slug,
+    creator_wallet,
+    reward_per_accuracy_pct,
+    reward_per_token_reduction_pct,
+    max_pool,
+    expires_in_days,
+  } = body;
+
+  if (!skill_slug || !creator_wallet || !max_pool) {
+    return NextResponse.json(
+      {
+        error: "Missing required fields: skill_slug, creator_wallet, max_pool",
+      },
+      { status: 400 }
+    );
+  }
+
+  const skill = getSkillBySlug(skill_slug);
+  if (!skill) {
+    return NextResponse.json(
+      { error: `Skill '${skill_slug}' not found` },
+      { status: 404 }
+    );
+  }
+
+  const bounty = createBounty({
+    skill_slug,
+    creator_wallet,
+    reward_per_accuracy_pct: reward_per_accuracy_pct ?? 5,
+    reward_per_token_reduction_pct: reward_per_token_reduction_pct ?? 2,
+    max_pool,
+    expires_in_days: expires_in_days ?? 30,
+  });
+
+  return NextResponse.json(bounty, { status: 201 });
+}

--- a/src/app/api/league/leaderboard/route.ts
+++ b/src/app/api/league/leaderboard/route.ts
@@ -1,0 +1,13 @@
+import { NextResponse } from "next/server";
+import { getLeaderboard, getActiveBounties } from "@/lib/bounty";
+
+export async function GET(): Promise<NextResponse> {
+  const leaderboard = getLeaderboard();
+  const activeBounties = getActiveBounties();
+
+  return NextResponse.json({
+    leaderboard,
+    active_bounties: activeBounties.length,
+    total_pool: activeBounties.reduce((sum, b) => sum + b.pool_remaining, 0),
+  });
+}

--- a/src/app/league/[id]/page.tsx
+++ b/src/app/league/[id]/page.tsx
@@ -1,0 +1,237 @@
+export const dynamic = "force-dynamic";
+
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import {
+  getBountyById,
+  getSubmissionsForBounty,
+  getAllBounties,
+} from "@/lib/bounty";
+import { getSkillBySlug } from "@/lib/skills";
+
+interface BountyDetailPageProps {
+  params: Promise<{ id: string }>;
+}
+
+export async function generateStaticParams() {
+  const bounties = getAllBounties();
+  return bounties.map((b) => ({ id: b.id }));
+}
+
+export default async function BountyDetailPage({
+  params,
+}: BountyDetailPageProps) {
+  const { id } = await params;
+  const bounty = getBountyById(id);
+
+  if (!bounty) {
+    notFound();
+  }
+
+  const skill = getSkillBySlug(bounty.skill_slug);
+  const submissions = getSubmissionsForBounty(bounty.id);
+
+  const poolPct =
+    bounty.max_pool > 0
+      ? Math.round((bounty.pool_remaining / bounty.max_pool) * 100)
+      : 0;
+
+  const daysLeft = Math.max(
+    0,
+    Math.ceil(
+      (new Date(bounty.expires_at).getTime() - Date.now()) /
+        (1000 * 60 * 60 * 24)
+    )
+  );
+
+  return (
+    <div className="min-h-screen bg-black text-white">
+      {/* Header */}
+      <header className="flex items-center justify-between border-b border-white/5 px-6 py-4 md:px-12">
+        <Link
+          href="/"
+          className="flex items-center gap-3 transition-opacity hover:opacity-80"
+        >
+          <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-lime">
+            <span className="text-sm font-bold text-black">CD</span>
+          </div>
+          <span className="hidden text-sm font-medium text-white/70 sm:block">
+            ContextDAO
+          </span>
+        </Link>
+        <nav className="flex items-center gap-6 text-sm text-white/50">
+          <Link
+            href="/league"
+            className="transition-colors hover:text-white/80"
+          >
+            League
+          </Link>
+          <Link
+            href="/marketplace"
+            className="transition-colors hover:text-white/80"
+          >
+            Marketplace
+          </Link>
+        </nav>
+      </header>
+
+      <main className="mx-auto max-w-4xl px-6 py-12 md:px-12">
+        {/* Back link */}
+        <Link
+          href="/league"
+          className="mb-6 inline-flex items-center gap-2 text-sm text-white/40 transition-colors hover:text-white/60"
+        >
+          &larr; Back to League
+        </Link>
+
+        {/* Bounty header */}
+        <div className="mb-8">
+          <div className="mb-2 flex items-center gap-3">
+            <span
+              className={`rounded-full px-3 py-1 text-xs font-medium ${
+                bounty.status === "active"
+                  ? "bg-lime/10 text-lime"
+                  : bounty.status === "depleted"
+                    ? "bg-red-500/10 text-red-400"
+                    : "bg-white/10 text-white/40"
+              }`}
+            >
+              {bounty.status}
+            </span>
+            <span className="text-sm text-white/30">{daysLeft}d remaining</span>
+          </div>
+          <h1 className="mb-2 text-3xl font-bold">
+            {skill?.metadata.name ?? bounty.skill_slug}
+          </h1>
+          <p className="text-white/50">
+            {skill?.metadata.description ?? "Optimize this skill for rewards"}
+          </p>
+        </div>
+
+        {/* Reward info */}
+        <div className="mb-8 grid gap-4 sm:grid-cols-3">
+          <div className="rounded-2xl border border-white/10 bg-white/[0.02] p-5">
+            <div className="text-xs uppercase tracking-wider text-white/40">
+              Per 1% accuracy gain
+            </div>
+            <div className="mt-2 text-2xl font-bold text-lime">
+              ${bounty.reward_per_accuracy_pct}
+            </div>
+            <div className="mt-1 text-xs text-white/30">USDC via x402</div>
+          </div>
+          <div className="rounded-2xl border border-white/10 bg-white/[0.02] p-5">
+            <div className="text-xs uppercase tracking-wider text-white/40">
+              Per 1% token reduction
+            </div>
+            <div className="mt-2 text-2xl font-bold text-white/80">
+              ${bounty.reward_per_token_reduction_pct}
+            </div>
+            <div className="mt-1 text-xs text-white/30">USDC via x402</div>
+          </div>
+          <div className="rounded-2xl border border-white/10 bg-white/[0.02] p-5">
+            <div className="text-xs uppercase tracking-wider text-white/40">
+              Pool remaining
+            </div>
+            <div className="mt-2 text-2xl font-bold text-white">
+              ${bounty.pool_remaining.toFixed(2)}
+            </div>
+            <div className="mt-2 h-2 overflow-hidden rounded-full bg-white/10">
+              <div
+                className="h-full rounded-full bg-lime"
+                style={{ width: `${poolPct}%` }}
+              />
+            </div>
+          </div>
+        </div>
+
+        {/* Submission API reference */}
+        <div className="mb-8 rounded-2xl border border-white/10 bg-white/[0.02] p-6">
+          <h2 className="mb-4 text-lg font-semibold">Submit an Optimization</h2>
+          <div className="rounded-xl bg-black/50 p-4">
+            <code className="block text-sm text-white/60">
+              <span className="text-lime">POST</span>{" "}
+              /api/league/bounties/{bounty.id}/submit
+            </code>
+            <pre className="mt-3 text-xs text-white/40">
+              {JSON.stringify(
+                {
+                  optimizer_wallet: "0xYOUR_WALLET",
+                  v2_content: "Your improved system prompt...",
+                },
+                null,
+                2
+              )}
+            </pre>
+          </div>
+          <p className="mt-3 text-sm text-white/40">
+            The Referee Agent will score your v2 against the validation set and
+            compare to the current v1. If improved, payout is automatic.
+          </p>
+        </div>
+
+        {/* Submissions */}
+        <div>
+          <h2 className="mb-4 text-lg font-semibold">
+            Submissions ({submissions.length})
+          </h2>
+          {submissions.length > 0 ? (
+            <div className="space-y-3">
+              {submissions.map((sub) => (
+                <div
+                  key={sub.id}
+                  className="flex items-center justify-between rounded-xl border border-white/10 bg-white/[0.02] px-5 py-4"
+                >
+                  <div className="flex items-center gap-4">
+                    <span
+                      className={`rounded-full px-2.5 py-0.5 text-xs font-medium ${
+                        sub.status === "accepted"
+                          ? "bg-lime/10 text-lime"
+                          : sub.status === "rejected"
+                            ? "bg-red-500/10 text-red-400"
+                            : sub.status === "evaluating"
+                              ? "bg-yellow-500/10 text-yellow-400"
+                              : "bg-white/10 text-white/40"
+                      }`}
+                    >
+                      {sub.status}
+                    </span>
+                    <code className="text-sm text-white/50">
+                      {sub.optimizer_wallet.slice(0, 6)}...
+                      {sub.optimizer_wallet.slice(-4)}
+                    </code>
+                  </div>
+                  <div className="flex items-center gap-4 text-sm">
+                    {sub.accuracy_delta !== undefined && (
+                      <span
+                        className={
+                          sub.accuracy_delta > 0
+                            ? "text-lime"
+                            : "text-white/40"
+                        }
+                      >
+                        {sub.accuracy_delta > 0 ? "+" : ""}
+                        {sub.accuracy_delta.toFixed(1)}%
+                      </span>
+                    )}
+                    {sub.payout !== undefined && sub.payout > 0 && (
+                      <span className="font-semibold text-lime">
+                        ${sub.payout.toFixed(2)}
+                      </span>
+                    )}
+                  </div>
+                </div>
+              ))}
+            </div>
+          ) : (
+            <div className="flex flex-col items-center justify-center rounded-2xl border border-dashed border-white/10 py-12 text-center">
+              <p className="text-white/50">No submissions yet</p>
+              <p className="mt-1 text-sm text-white/30">
+                Be the first to optimize this skill
+              </p>
+            </div>
+          )}
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/src/app/league/page.tsx
+++ b/src/app/league/page.tsx
@@ -1,0 +1,189 @@
+export const dynamic = "force-dynamic";
+
+import Link from "next/link";
+import { getActiveBounties, getAllBounties, getLeaderboard } from "@/lib/bounty";
+import { getSkillBySlug } from "@/lib/skills";
+import { BountyCard } from "@/components/league/bounty-card";
+import { LeaderboardTable } from "@/components/league/leaderboard-table";
+
+export const metadata = {
+  title: "Validation League — ContextDAO",
+  description:
+    "Optimize cognitive assets for yield. Bittensor-style bounties for prompt engineering.",
+};
+
+export default function LeaguePage() {
+  const activeBounties = getActiveBounties();
+  const allBounties = getAllBounties();
+  const leaderboard = getLeaderboard();
+
+  const totalPool = activeBounties.reduce(
+    (sum, b) => sum + b.pool_remaining,
+    0
+  );
+  const totalPaidOut = allBounties.reduce(
+    (sum, b) => sum + (b.max_pool - b.pool_remaining),
+    0
+  );
+
+  // Enrich bounties with skill names
+  const enrichedBounties = activeBounties.map((b) => {
+    const skill = getSkillBySlug(b.skill_slug);
+    return {
+      ...b,
+      skill_name: skill?.metadata.name,
+    };
+  });
+
+  return (
+    <div className="min-h-screen bg-black text-white">
+      {/* Header */}
+      <header className="flex items-center justify-between border-b border-white/5 px-6 py-4 md:px-12">
+        <Link
+          href="/"
+          className="flex items-center gap-3 transition-opacity hover:opacity-80"
+        >
+          <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-lime">
+            <span className="text-sm font-bold text-black">CD</span>
+          </div>
+          <span className="hidden text-sm font-medium text-white/70 sm:block">
+            ContextDAO
+          </span>
+        </Link>
+        <nav className="flex items-center gap-6 text-sm text-white/50">
+          <span className="text-white">League</span>
+          <Link
+            href="/marketplace"
+            className="transition-colors hover:text-white/80"
+          >
+            Marketplace
+          </Link>
+          <Link href="/" className="transition-colors hover:text-white/80">
+            Home
+          </Link>
+        </nav>
+      </header>
+
+      <main className="mx-auto max-w-6xl px-6 py-12 md:px-12">
+        {/* Hero */}
+        <div className="mb-12">
+          <div className="mb-4 inline-flex items-center gap-2 rounded-full border border-lime/30 bg-lime/10 px-4 py-1.5 text-sm text-lime">
+            <span className="h-2 w-2 animate-pulse rounded-full bg-lime" />
+            Validation League
+          </div>
+          <h1 className="mb-3 text-3xl font-bold md:text-4xl">
+            Optimize for Yield
+          </h1>
+          <p className="max-w-2xl text-lg text-white/50">
+            Submit improved skill versions. If your optimization beats the
+            current score, you get paid automatically via x402.
+            Bittensor-style incentives for prompt engineering.
+          </p>
+        </div>
+
+        {/* Stats */}
+        <div className="mb-12 grid grid-cols-2 gap-4 md:grid-cols-4">
+          {[
+            {
+              label: "Active Bounties",
+              value: activeBounties.length.toString(),
+            },
+            {
+              label: "Total Pool",
+              value: `$${totalPool.toFixed(2)}`,
+              accent: true,
+            },
+            {
+              label: "Paid Out",
+              value: `$${totalPaidOut.toFixed(2)}`,
+            },
+            {
+              label: "Optimizers",
+              value: leaderboard.length.toString(),
+            },
+          ].map((stat) => (
+            <div
+              key={stat.label}
+              className="rounded-2xl border border-white/10 bg-white/[0.02] p-5"
+            >
+              <div className="text-xs uppercase tracking-wider text-white/40">
+                {stat.label}
+              </div>
+              <div
+                className={`mt-2 text-2xl font-bold ${stat.accent ? "text-lime" : "text-white"}`}
+              >
+                {stat.value}
+              </div>
+            </div>
+          ))}
+        </div>
+
+        {/* Active Bounties */}
+        <section className="mb-12">
+          <h2 className="mb-6 text-xl font-semibold">Active Bounties</h2>
+          {enrichedBounties.length > 0 ? (
+            <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+              {enrichedBounties.map((bounty) => (
+                <BountyCard key={bounty.id} bounty={bounty} />
+              ))}
+            </div>
+          ) : (
+            <div className="flex flex-col items-center justify-center rounded-2xl border border-dashed border-white/10 py-16 text-center">
+              <div className="mb-3 text-3xl">&#127942;</div>
+              <p className="text-white/50">No active bounties</p>
+              <p className="mt-1 text-sm text-white/30">
+                Create a bounty via the API to start the optimization flywheel
+              </p>
+              <code className="mt-4 rounded-lg bg-white/5 px-4 py-2 text-xs text-white/40">
+                POST /api/league/bounties
+              </code>
+            </div>
+          )}
+        </section>
+
+        {/* Leaderboard */}
+        <section className="mb-12">
+          <h2 className="mb-6 text-xl font-semibold">Leaderboard</h2>
+          <LeaderboardTable entries={leaderboard} />
+        </section>
+
+        {/* How it works */}
+        <section>
+          <h2 className="mb-6 text-xl font-semibold">How It Works</h2>
+          <div className="grid gap-6 md:grid-cols-3">
+            {[
+              {
+                step: "1",
+                title: "Pick a Bounty",
+                desc: "Choose a skill to optimize. Download the current version and study the validation criteria.",
+              },
+              {
+                step: "2",
+                title: "Submit v2",
+                desc: "Improve the system prompt. Better accuracy, fewer tokens, or both. Submit your optimized version.",
+              },
+              {
+                step: "3",
+                title: "Get Paid",
+                desc: "The Referee Agent scores both versions. If yours wins, USDC payment is triggered automatically via x402.",
+              },
+            ].map((item) => (
+              <div
+                key={item.step}
+                className="rounded-2xl border border-white/10 bg-white/[0.02] p-6"
+              >
+                <div className="mb-3 flex h-10 w-10 items-center justify-center rounded-full bg-lime/10 text-lg font-bold text-lime">
+                  {item.step}
+                </div>
+                <h3 className="mb-2 font-semibold">{item.title}</h3>
+                <p className="text-sm leading-relaxed text-white/50">
+                  {item.desc}
+                </p>
+              </div>
+            ))}
+          </div>
+        </section>
+      </main>
+    </div>
+  );
+}

--- a/src/app/marketplace/page.tsx
+++ b/src/app/marketplace/page.tsx
@@ -45,6 +45,9 @@ export default async function MarketplacePage({
         </Link>
         <nav className="flex items-center gap-6 text-sm text-white/50">
           <span className="text-white">Marketplace</span>
+          <Link href="/league" className="transition-colors hover:text-white/80">
+            League
+          </Link>
           <Link href="/" className="transition-colors hover:text-white/80">
             Home
           </Link>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -149,6 +149,12 @@ export default function HomePage() {
               <MagneticButton href="/marketplace">
                 Browse Marketplace
               </MagneticButton>
+              <a
+                href="/league"
+                className="inline-flex items-center gap-2 px-6 py-4 border border-white/20 text-white/70 font-medium text-lg rounded-full hover:border-lime/40 hover:text-white transition-colors"
+              >
+                Validation League
+              </a>
             </motion.div>
             <motion.p
               initial={{ opacity: 0 }}

--- a/src/components/league/bounty-card.tsx
+++ b/src/components/league/bounty-card.tsx
@@ -1,0 +1,97 @@
+import Link from "next/link";
+
+interface BountyCardProps {
+  bounty: {
+    id: string;
+    skill_slug: string;
+    reward_per_accuracy_pct: number;
+    reward_per_token_reduction_pct: number;
+    pool_remaining: number;
+    max_pool: number;
+    expires_at: string;
+    status: string;
+    skill_name?: string;
+  };
+}
+
+export function BountyCard({ bounty }: BountyCardProps) {
+  const poolPct =
+    bounty.max_pool > 0
+      ? Math.round((bounty.pool_remaining / bounty.max_pool) * 100)
+      : 0;
+
+  const daysLeft = Math.max(
+    0,
+    Math.ceil(
+      (new Date(bounty.expires_at).getTime() - Date.now()) /
+        (1000 * 60 * 60 * 24)
+    )
+  );
+
+  return (
+    <Link href={`/league/${bounty.id}`}>
+      <div className="group rounded-2xl border border-white/10 bg-white/[0.02] p-6 transition-all hover:border-lime/30 hover:bg-white/[0.04]">
+        {/* Header */}
+        <div className="mb-4 flex items-start justify-between">
+          <div>
+            <h3 className="font-semibold text-white">
+              {bounty.skill_name ?? bounty.skill_slug}
+            </h3>
+            <p className="mt-1 text-sm text-white/40">{bounty.skill_slug}</p>
+          </div>
+          <span
+            className={`rounded-full px-3 py-1 text-xs font-medium ${
+              bounty.status === "active"
+                ? "bg-lime/10 text-lime"
+                : bounty.status === "depleted"
+                  ? "bg-red-500/10 text-red-400"
+                  : "bg-white/10 text-white/40"
+            }`}
+          >
+            {bounty.status}
+          </span>
+        </div>
+
+        {/* Rewards */}
+        <div className="mb-4 grid grid-cols-2 gap-3">
+          <div className="rounded-xl bg-white/5 p-3">
+            <div className="text-xs text-white/40">Per 1% accuracy</div>
+            <div className="mt-1 text-lg font-bold text-lime">
+              ${bounty.reward_per_accuracy_pct}
+            </div>
+          </div>
+          <div className="rounded-xl bg-white/5 p-3">
+            <div className="text-xs text-white/40">Per 1% token save</div>
+            <div className="mt-1 text-lg font-bold text-white/80">
+              ${bounty.reward_per_token_reduction_pct}
+            </div>
+          </div>
+        </div>
+
+        {/* Pool bar */}
+        <div className="mb-3">
+          <div className="mb-1 flex items-center justify-between text-xs text-white/40">
+            <span>Pool remaining</span>
+            <span>
+              ${bounty.pool_remaining.toFixed(2)} / ${bounty.max_pool.toFixed(2)}
+            </span>
+          </div>
+          <div className="h-2 overflow-hidden rounded-full bg-white/10">
+            <div
+              className="h-full rounded-full bg-lime transition-all"
+              style={{ width: `${poolPct}%` }}
+            />
+          </div>
+        </div>
+
+        {/* Footer */}
+        <div className="flex items-center justify-between text-xs text-white/30">
+          <span>{daysLeft}d remaining</span>
+          <span className="text-white/50 transition-colors group-hover:text-lime">
+            View details &rarr;
+          </span>
+        </div>
+      </div>
+    </Link>
+  );
+}

--- a/src/components/league/leaderboard-table.tsx
+++ b/src/components/league/leaderboard-table.tsx
@@ -1,0 +1,93 @@
+interface LeaderboardEntry {
+  wallet: string;
+  total_earnings: number;
+  submissions_accepted: number;
+  submissions_total: number;
+  best_accuracy_delta: number;
+}
+
+interface LeaderboardTableProps {
+  entries: LeaderboardEntry[];
+}
+
+export function LeaderboardTable({ entries }: LeaderboardTableProps) {
+  if (entries.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center rounded-2xl border border-dashed border-white/10 py-16 text-center">
+        <div className="mb-3 text-3xl">&#9878;</div>
+        <p className="text-white/50">No optimizers yet</p>
+        <p className="mt-1 text-sm text-white/30">
+          Submit an improved skill to appear here
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="overflow-hidden rounded-2xl border border-white/10">
+      <table className="w-full">
+        <thead>
+          <tr className="border-b border-white/10 bg-white/[0.02]">
+            <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-white/40">
+              Rank
+            </th>
+            <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-white/40">
+              Optimizer
+            </th>
+            <th className="px-6 py-3 text-right text-xs font-medium uppercase tracking-wider text-white/40">
+              Earnings
+            </th>
+            <th className="hidden px-6 py-3 text-right text-xs font-medium uppercase tracking-wider text-white/40 sm:table-cell">
+              Accepted
+            </th>
+            <th className="hidden px-6 py-3 text-right text-xs font-medium uppercase tracking-wider text-white/40 md:table-cell">
+              Best Delta
+            </th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-white/5">
+          {entries.map((entry, i) => (
+            <tr
+              key={entry.wallet}
+              className="transition-colors hover:bg-white/[0.02]"
+            >
+              <td className="px-6 py-4">
+                <span
+                  className={`inline-flex h-7 w-7 items-center justify-center rounded-full text-sm font-bold ${
+                    i === 0
+                      ? "bg-lime/20 text-lime"
+                      : i === 1
+                        ? "bg-white/10 text-white/70"
+                        : i === 2
+                          ? "bg-orange-500/10 text-orange-400"
+                          : "text-white/30"
+                  }`}
+                >
+                  {i + 1}
+                </span>
+              </td>
+              <td className="px-6 py-4">
+                <code className="text-sm text-white/60">
+                  {entry.wallet.slice(0, 6)}...{entry.wallet.slice(-4)}
+                </code>
+              </td>
+              <td className="px-6 py-4 text-right">
+                <span className="font-semibold text-lime">
+                  ${entry.total_earnings.toFixed(2)}
+                </span>
+              </td>
+              <td className="hidden px-6 py-4 text-right text-sm text-white/50 sm:table-cell">
+                {entry.submissions_accepted}/{entry.submissions_total}
+              </td>
+              <td className="hidden px-6 py-4 text-right text-sm md:table-cell">
+                <span className="text-lime">
+                  +{entry.best_accuracy_delta.toFixed(1)}%
+                </span>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/src/lib/bounty.ts
+++ b/src/lib/bounty.ts
@@ -1,0 +1,231 @@
+/**
+ * Bounty System — in-memory store for Validation League bounties.
+ *
+ * In production this would be backed by a database + x402 escrow.
+ * For MVP, we use a JSON file for persistence across server restarts.
+ */
+
+import fs from "fs";
+import path from "path";
+
+// --- Types ---
+
+export interface Bounty {
+  id: string;
+  skill_slug: string;
+  creator_wallet: string;
+  reward_per_accuracy_pct: number;
+  reward_per_token_reduction_pct: number;
+  max_pool: number;
+  pool_remaining: number;
+  expires_at: string;
+  created_at: string;
+  status: "active" | "expired" | "depleted";
+}
+
+export interface Submission {
+  id: string;
+  bounty_id: string;
+  skill_slug: string;
+  optimizer_wallet: string;
+  submitted_at: string;
+  v2_content: string;
+  status: "pending" | "evaluating" | "accepted" | "rejected";
+  accuracy_delta?: number;
+  token_delta?: number;
+  payout?: number;
+  verdict_timestamp?: string;
+}
+
+export interface LeaderboardEntry {
+  wallet: string;
+  total_earnings: number;
+  submissions_accepted: number;
+  submissions_total: number;
+  best_accuracy_delta: number;
+}
+
+// --- Storage ---
+
+const DATA_DIR = path.join(process.cwd(), ".league-data");
+
+function ensureDataDir() {
+  if (!fs.existsSync(DATA_DIR)) {
+    fs.mkdirSync(DATA_DIR, { recursive: true });
+  }
+}
+
+function loadJson<T>(filename: string, fallback: T): T {
+  ensureDataDir();
+  const filePath = path.join(DATA_DIR, filename);
+  if (!fs.existsSync(filePath)) return fallback;
+  return JSON.parse(fs.readFileSync(filePath, "utf-8")) as T;
+}
+
+function saveJson<T>(filename: string, data: T): void {
+  ensureDataDir();
+  const filePath = path.join(DATA_DIR, filename);
+  fs.writeFileSync(filePath, JSON.stringify(data, null, 2));
+}
+
+// --- Bounty CRUD ---
+
+export function getAllBounties(): Bounty[] {
+  const bounties = loadJson<Bounty[]>("bounties.json", []);
+  // Auto-expire
+  const now = new Date();
+  return bounties.map((b) => ({
+    ...b,
+    status:
+      b.pool_remaining <= 0
+        ? "depleted"
+        : new Date(b.expires_at) < now
+          ? "expired"
+          : b.status,
+  }));
+}
+
+export function getActiveBounties(): Bounty[] {
+  return getAllBounties().filter((b) => b.status === "active");
+}
+
+export function getBountyById(id: string): Bounty | null {
+  return getAllBounties().find((b) => b.id === id) ?? null;
+}
+
+export function getBountiesForSkill(slug: string): Bounty[] {
+  return getActiveBounties().filter((b) => b.skill_slug === slug);
+}
+
+let bountyCounter = 0;
+
+export function createBounty(params: {
+  skill_slug: string;
+  creator_wallet: string;
+  reward_per_accuracy_pct: number;
+  reward_per_token_reduction_pct: number;
+  max_pool: number;
+  expires_in_days: number;
+}): Bounty {
+  const bounties = loadJson<Bounty[]>("bounties.json", []);
+  bountyCounter = bounties.length;
+
+  const bounty: Bounty = {
+    id: `bounty-${++bountyCounter}-${Date.now()}`,
+    skill_slug: params.skill_slug,
+    creator_wallet: params.creator_wallet,
+    reward_per_accuracy_pct: params.reward_per_accuracy_pct,
+    reward_per_token_reduction_pct: params.reward_per_token_reduction_pct,
+    max_pool: params.max_pool,
+    pool_remaining: params.max_pool,
+    expires_at: new Date(
+      Date.now() + params.expires_in_days * 24 * 60 * 60 * 1000
+    ).toISOString(),
+    created_at: new Date().toISOString(),
+    status: "active",
+  };
+
+  bounties.push(bounty);
+  saveJson("bounties.json", bounties);
+  return bounty;
+}
+
+// --- Submission CRUD ---
+
+let submissionCounter = 0;
+
+export function createSubmission(params: {
+  bounty_id: string;
+  skill_slug: string;
+  optimizer_wallet: string;
+  v2_content: string;
+}): Submission {
+  const submissions = loadJson<Submission[]>("submissions.json", []);
+  submissionCounter = submissions.length;
+
+  const submission: Submission = {
+    id: `sub-${++submissionCounter}-${Date.now()}`,
+    bounty_id: params.bounty_id,
+    skill_slug: params.skill_slug,
+    optimizer_wallet: params.optimizer_wallet,
+    submitted_at: new Date().toISOString(),
+    v2_content: params.v2_content,
+    status: "pending",
+  };
+
+  submissions.push(submission);
+  saveJson("submissions.json", submissions);
+  return submission;
+}
+
+export function getSubmission(id: string): Submission | null {
+  const submissions = loadJson<Submission[]>("submissions.json", []);
+  return submissions.find((s) => s.id === id) ?? null;
+}
+
+export function getSubmissionsForBounty(bountyId: string): Submission[] {
+  const submissions = loadJson<Submission[]>("submissions.json", []);
+  return submissions.filter((s) => s.bounty_id === bountyId);
+}
+
+export function updateSubmission(
+  id: string,
+  update: Partial<Submission>
+): Submission | null {
+  const submissions = loadJson<Submission[]>("submissions.json", []);
+  const idx = submissions.findIndex((s) => s.id === id);
+  if (idx === -1) return null;
+
+  submissions[idx] = { ...submissions[idx], ...update };
+  saveJson("submissions.json", submissions);
+  return submissions[idx];
+}
+
+export function deductBountyPool(id: string, amount: number): boolean {
+  const bounties = loadJson<Bounty[]>("bounties.json", []);
+  const idx = bounties.findIndex((b) => b.id === id);
+  if (idx === -1) return false;
+
+  bounties[idx].pool_remaining = Math.max(
+    0,
+    bounties[idx].pool_remaining - amount
+  );
+  if (bounties[idx].pool_remaining <= 0) {
+    bounties[idx].status = "depleted";
+  }
+  saveJson("bounties.json", bounties);
+  return true;
+}
+
+// --- Leaderboard ---
+
+export function getLeaderboard(): LeaderboardEntry[] {
+  const submissions = loadJson<Submission[]>("submissions.json", []);
+  const walletMap = new Map<string, LeaderboardEntry>();
+
+  for (const sub of submissions) {
+    const entry = walletMap.get(sub.optimizer_wallet) ?? {
+      wallet: sub.optimizer_wallet,
+      total_earnings: 0,
+      submissions_accepted: 0,
+      submissions_total: 0,
+      best_accuracy_delta: 0,
+    };
+
+    entry.submissions_total++;
+
+    if (sub.status === "accepted" && sub.payout) {
+      entry.submissions_accepted++;
+      entry.total_earnings += sub.payout;
+      if (sub.accuracy_delta && sub.accuracy_delta > entry.best_accuracy_delta) {
+        entry.best_accuracy_delta = sub.accuracy_delta;
+      }
+    }
+
+    walletMap.set(sub.optimizer_wallet, entry);
+  }
+
+  return Array.from(walletMap.values()).sort(
+    (a, b) => b.total_earnings - a.total_earnings
+  );
+}

--- a/src/lib/referee.ts
+++ b/src/lib/referee.ts
@@ -1,0 +1,247 @@
+/**
+ * Referee Engine — automated validation pipeline for the Validation League.
+ *
+ * Runs both v1 and v2 of a skill against the validation set,
+ * scores responses, and calculates improvement delta.
+ */
+
+import fs from "fs";
+import path from "path";
+import { runInference } from "./llm-client";
+
+// --- Types ---
+
+export interface ValidationQuestion {
+  input: string;
+  expected_output: string;
+  match_type: "keyword" | "llm_judge" | "exact" | "contains";
+  weight: number;
+}
+
+export interface ValidationSet {
+  skill: string;
+  version: string;
+  questions: ValidationQuestion[];
+}
+
+export interface QuestionResult {
+  input: string;
+  match_type: string;
+  score: number;
+  max_score: number;
+  tokens_used: number;
+}
+
+export interface SkillRunResult {
+  total_score: number;
+  max_score: number;
+  accuracy_pct: number;
+  total_tokens: number;
+  question_results: QuestionResult[];
+}
+
+export interface RefereeVerdict {
+  skill_slug: string;
+  v1_score: SkillRunResult;
+  v2_score: SkillRunResult;
+  accuracy_delta: number;
+  token_delta: number;
+  improved: boolean;
+  timestamp: string;
+}
+
+// --- Validation Set Loader ---
+
+export function loadValidationSet(slug: string): ValidationSet | null {
+  const candidates = [
+    path.join(process.cwd(), "skills", slug, "validation.json"),
+    path.join(process.cwd(), "..", "skills", slug, "validation.json"),
+  ];
+
+  for (const filePath of candidates) {
+    if (fs.existsSync(filePath)) {
+      const raw = fs.readFileSync(filePath, "utf-8");
+      return JSON.parse(raw) as ValidationSet;
+    }
+  }
+
+  return null;
+}
+
+// --- Scorers ---
+
+function scoreKeyword(response: string, expected: string): number {
+  // Expected format: "keyword1, keyword2, keyword3" or "contains: kw1, kw2"
+  const cleaned = expected.replace(/^contains:\s*/i, "");
+  const keywords = cleaned.split(",").map((k) => k.trim().toLowerCase());
+  const responseLower = response.toLowerCase();
+
+  const matched = keywords.filter((kw) => responseLower.includes(kw));
+  return matched.length / keywords.length;
+}
+
+function scoreExact(response: string, expected: string): number {
+  return response.trim().toLowerCase() === expected.trim().toLowerCase()
+    ? 1.0
+    : 0.0;
+}
+
+function scoreContains(response: string, expected: string): number {
+  return response.toLowerCase().includes(expected.toLowerCase()) ? 1.0 : 0.0;
+}
+
+async function scoreLlmJudge(
+  input: string,
+  response: string,
+  expected: string
+): Promise<number> {
+  const judgePrompt = `You are a strict evaluator. Score the following response on a scale of 0 to 10.
+
+QUESTION: ${input}
+
+EXPECTED CRITERIA: ${expected}
+
+ACTUAL RESPONSE: ${response}
+
+Reply with ONLY a JSON object: {"score": <number 0-10>, "reason": "<brief reason>"}`;
+
+  try {
+    const result = await runInference({
+      systemPrompt: "You are a precise evaluation judge. Always respond with valid JSON.",
+      userPrompt: judgePrompt,
+      model: "claude-haiku-4-5-20251001",
+      maxTokens: 200,
+    });
+
+    const parsed = JSON.parse(result.response);
+    return Math.min(10, Math.max(0, parsed.score)) / 10;
+  } catch {
+    // Fallback to keyword scoring if LLM judge fails
+    return scoreKeyword(response, expected);
+  }
+}
+
+// --- Core Runner ---
+
+async function runSkillAgainstValidation(
+  skillContent: string,
+  validationSet: ValidationSet
+): Promise<SkillRunResult> {
+  const results: QuestionResult[] = [];
+  let totalScore = 0;
+  let maxScore = 0;
+  let totalTokens = 0;
+
+  for (const q of validationSet.questions) {
+    const weight = q.weight ?? 1.0;
+    maxScore += weight;
+
+    try {
+      const inference = await runInference({
+        systemPrompt: skillContent,
+        userPrompt: q.input,
+        maxTokens: 1024,
+      });
+
+      let score: number;
+
+      switch (q.match_type) {
+        case "keyword":
+          score = scoreKeyword(inference.response, q.expected_output);
+          break;
+        case "exact":
+          score = scoreExact(inference.response, q.expected_output);
+          break;
+        case "contains":
+          score = scoreContains(inference.response, q.expected_output);
+          break;
+        case "llm_judge":
+          score = await scoreLlmJudge(
+            q.input,
+            inference.response,
+            q.expected_output
+          );
+          break;
+        default:
+          score = 0;
+      }
+
+      const weightedScore = score * weight;
+      totalScore += weightedScore;
+      totalTokens += inference.tokens_in + inference.tokens_out;
+
+      results.push({
+        input: q.input,
+        match_type: q.match_type,
+        score: weightedScore,
+        max_score: weight,
+        tokens_used: inference.tokens_in + inference.tokens_out,
+      });
+    } catch {
+      results.push({
+        input: q.input,
+        match_type: q.match_type,
+        score: 0,
+        max_score: weight,
+        tokens_used: 0,
+      });
+    }
+  }
+
+  return {
+    total_score: Math.round(totalScore * 100) / 100,
+    max_score: maxScore,
+    accuracy_pct: maxScore > 0 ? Math.round((totalScore / maxScore) * 10000) / 100 : 0,
+    total_tokens: totalTokens,
+    question_results: results,
+  };
+}
+
+// --- Public API ---
+
+/**
+ * Run the full referee pipeline: score v1, score v2, calculate delta.
+ */
+export async function referee(
+  slug: string,
+  v1Content: string,
+  v2Content: string
+): Promise<RefereeVerdict> {
+  const validationSet = loadValidationSet(slug);
+  if (!validationSet) {
+    throw new Error(`No validation set found for skill '${slug}'`);
+  }
+
+  const [v1Score, v2Score] = await Promise.all([
+    runSkillAgainstValidation(v1Content, validationSet),
+    runSkillAgainstValidation(v2Content, validationSet),
+  ]);
+
+  const accuracyDelta = v2Score.accuracy_pct - v1Score.accuracy_pct;
+  const tokenDelta = v1Score.total_tokens - v2Score.total_tokens;
+
+  return {
+    skill_slug: slug,
+    v1_score: v1Score,
+    v2_score: v2Score,
+    accuracy_delta: Math.round(accuracyDelta * 100) / 100,
+    token_delta: tokenDelta,
+    improved: accuracyDelta > 0 || (accuracyDelta === 0 && tokenDelta > 0),
+    timestamp: new Date().toISOString(),
+  };
+}
+
+/**
+ * Score a single skill version against its validation set.
+ */
+export async function scoreSkill(
+  slug: string,
+  skillContent: string
+): Promise<SkillRunResult> {
+  const validationSet = loadValidationSet(slug);
+  if (!validationSet) {
+    throw new Error(`No validation set found for skill '${slug}'`);
+  }
+
+  return runSkillAgainstValidation(skillContent, validationSet);
+}


### PR DESCRIPTION
## Summary
- **Referee Engine** (`src/lib/referee.ts`): Scores skills against validation sets using 4 methods — keyword, exact, contains, LLM-as-Judge (Claude Haiku). Runs v1 vs v2 in parallel, calculates accuracy + token deltas
- **Bounty System** (`src/lib/bounty.ts`): JSON file-backed store for bounties and submissions. Auto-calculates payouts based on improvement, deducts from pool, tracks optimizer earnings
- **API Routes**: `POST/GET /api/league/bounties`, `GET /api/league/bounties/[id]`, `POST /api/league/bounties/[id]/submit`, `GET /api/league/leaderboard`
- **League UI**: `/league` page with stats, active bounties grid, leaderboard table, "How it works" section. `/league/[id]` bounty detail with submission history and API reference
- Nav links added to home page and marketplace

## Test plan
- [ ] `npm run build` passes cleanly
- [ ] `/league` page renders with empty state
- [ ] `POST /api/league/bounties` creates a bounty
- [ ] `GET /api/league/bounties` lists active bounties
- [ ] `POST /api/league/bounties/[id]/submit` with ANTHROPIC_API_KEY runs referee evaluation
- [ ] `/league` shows leaderboard after accepted submissions

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)